### PR TITLE
fix the link to alto.build

### DIFF
--- a/Frontend-v1-Original/components/ssVests/partnersVests.tsx
+++ b/Frontend-v1-Original/components/ssVests/partnersVests.tsx
@@ -12,7 +12,7 @@ const partners: PartnerCardProps[] = [
     title: "Alto.build",
     description:
       "To buy or sell a veFLOW positions, visit Alto.build. The premier NFT market place on Canto.",
-    link: "https://alto.build/",
+    link: "https://alto.build/collections/flow",
     logo: "https://alto.build/_next/image?url=%2Falto-logo-v2.png&w=48&q=75",
   },
   {


### PR DESCRIPTION
So users don't have to search `veNFT` on alto.build for it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `partnersVests.tsx` file in the `ssVests` component of `Frontend-v1-Original`. It changes the `link` property for the `Alto.build` partner to point to a specific collection on the site. 

### Detailed summary
- Updated `link` property for `Alto.build` partner to point to a specific collection on the site.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->