### PR TITLE
Improve table sorting + minor adjustments

### DIFF
--- a/Frontend-v1-Original/components/ssBribeCreate/ssBribeCreate.tsx
+++ b/Frontend-v1-Original/components/ssBribeCreate/ssBribeCreate.tsx
@@ -549,7 +549,7 @@ function AssetSelect({
               autoFocus
               variant="outlined"
               fullWidth
-              placeholder="WCANTO, NOTE, 0x..."
+              placeholder="CANTO, NOTE, 0x..."
               value={search}
               onChange={onSearchChanged}
               InputProps={{
@@ -589,7 +589,7 @@ function AssetSelect({
               autoFocus
               variant="outlined"
               fullWidth
-              placeholder="WCANTO, NOTE, 0x..."
+              placeholder="CANTO, NOTE, 0x..."
               value={search}
               onChange={onSearchChanged}
               InputProps={{

--- a/Frontend-v1-Original/components/ssBribes/ssBribes.tsx
+++ b/Frontend-v1-Original/components/ssBribes/ssBribes.tsx
@@ -69,7 +69,7 @@ export default function ssBribes() {
         }}
       >
         <Typography className={classes.actionButtonText}>
-          Create bribe
+          Create Bribe
         </Typography>
       </Button>
       {/* <div className={classes.bribesContainer}>

--- a/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
@@ -1071,6 +1071,17 @@ function descendingComparator(a: Pair, b: Pair, orderBy: OrderBy) {
   }
 
   switch (orderBy) {
+    case "pair":
+      let caseA = a.symbol.toLowerCase();
+      let caseB = b.symbol.toLowerCase();
+      if (caseB < caseA) {
+        return -1;
+      }
+      if (caseB > caseA) {
+        return 1;
+      }
+      return 0;
+
     case "balance":
       if (
         !isBaseAsset(a.token0) ||

--- a/Frontend-v1-Original/components/ssRewards/ssRewards.module.css
+++ b/Frontend-v1-Original/components/ssRewards/ssRewards.module.css
@@ -6,7 +6,6 @@
   align-items: flex-end;
   margin: auto;
   margin-bottom: 60px;
-  padding: 20px 0 10px 0px;
 }
 
 .descriptionBox {
@@ -42,7 +41,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  margin-bottom: 24px;
+  padding: 24px 0;
 }
 
 .searchContainer {

--- a/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
+++ b/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
@@ -216,6 +216,7 @@ export default function ssRewards() {
                                 {formatCurrency(option.lockValue)}
                               </Typography>
                               <Typography
+                                align="right"
                                 color="textSecondary"
                                 className={classes.smallerText}
                               >

--- a/Frontend-v1-Original/components/ssRewards/ssRewardsTable.tsx
+++ b/Frontend-v1-Original/components/ssRewards/ssRewardsTable.tsx
@@ -594,10 +594,12 @@ function descendingComparator(
         }
       }
       if (isGaugeReward(a) && isGaugeReward(b)) {
-        if (b.symbol < a.symbol) {
+        let caseA = a.symbol.toLowerCase();
+        let caseB = b.symbol.toLowerCase();
+        if (caseB < caseA) {
           return -1;
         }
-        if (b.symbol > a.symbol) {
+        if (caseB > caseA) {
           return 1;
         }
       }

--- a/Frontend-v1-Original/components/ssVotes/ssVotes.tsx
+++ b/Frontend-v1-Original/components/ssVotes/ssVotes.tsx
@@ -251,6 +251,7 @@ export default function ssVotes() {
                                 {formatCurrency(option.lockValue)}
                               </Typography>
                               <Typography
+                                align="right"
                                 color="textSecondary"
                                 className={classes.smallerText}
                               >

--- a/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
+++ b/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
@@ -503,6 +503,17 @@ function descendingComparator(
   }
 
   switch (orderBy) {
+    case "asset":
+      let caseA = a.symbol.toLowerCase();
+      let caseB = b.symbol.toLowerCase();
+      if (caseB < caseA) {
+        return -1;
+      }
+      if (caseB > caseA) {
+        return 1;
+      }
+      return 0;
+
     case "votingAPR":
       if (BigNumber(b.gauge.apr).lt(a.gauge.apr)) {
         return -1;
@@ -580,13 +591,13 @@ function descendingComparator(
       return 0;
 
     case "totalVotes":
-      if (!a.gauge.weightPercent || !b.gauge.weightPercent) {
+      if (!a.gauge.weight || !b.gauge.weight) {
         return 0;
       }
-      if (BigNumber(b.gauge.weightPercent).lt(a.gauge.weightPercent)) {
+      if (BigNumber(b.gauge.weight).lt(a.gauge.weight)) {
         return -1;
       }
-      if (BigNumber(b.gauge.weightPercent).gt(a.gauge.weightPercent)) {
+      if (BigNumber(b.gauge.weight).gt(a.gauge.weight)) {
         return 1;
       }
       return 0;


### PR DESCRIPTION
**Liquidity Page**
- Allow sorting by Pair name

**Vote Page**
- Allow sorting by Asset name
- Fix sorting by Total Votes (assets with the same percentage such as 0.00% with differing amounts of votes were sorting wrong)
- Right align veFLOW text in veNFT dropdown

**Rewards Page**
- Fix sorting by Pool name for case-sensitivity
- Adjust header/toolbar padding to match the other pages
- Right align veFLOW text in veNFT dropdown

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors several components in the Frontend-v1-Original directory to improve UI design and add functionality. 

### Detailed summary:
- Modify typography alignment and color in ssVotes, ssRewards, and ssBribes components
- Change "Create bribe" text to "Create Bribe" in ssBribes
- Adjust margin and padding in ssRewards styles
- Update sorting logic in ssRewardsTable, ssLiquidityPairsTable, and ssVotesTable components based on symbol and weight
- Change placeholder text in AssetSelect and ssBribeCreate components from "WCANTO, NOTE, 0x..." to "CANTO, NOTE, 0x..."
- Modify descendingComparator function in ssVotesTable to sort by weight instead of weightPercentage in totalVotes case

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->