### PR TITLE
Hotfix/two rows of bribes

### DIFF
--- a/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
+++ b/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
@@ -90,7 +90,12 @@ export default function Rewards() {
         rew.xBribes.length >= 0 &&
         rew.rewards.length >= 0
       ) {
-        setRewards([...rew.bribes, ...rew.rewards, ...rew.veDist]);
+        setRewards([
+          ...rew.xBribes,
+          ...rew.bribes,
+          ...rew.rewards,
+          ...rew.veDist,
+        ]);
       }
     } else {
       let re = stores.stableSwapStore.getStore("rewards");
@@ -105,7 +110,7 @@ export default function Rewards() {
         re.xBribes.length >= 0 &&
         re.rewards.length >= 0
       ) {
-        setRewards([...re.bribes, ...re.rewards, ...re.veDist]);
+        setRewards([...re.xBribes, ...re.bribes, ...re.rewards, ...re.veDist]);
       }
     }
   };

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -5924,7 +5924,7 @@ class Store {
 
       const gauges = pairs.filter(hasGauge);
 
-      if (typeof window.structuredClone === "undefined") {
+      if (!("structuredCline" in window)) {
         throw new Error(
           "Your browser does not support structuredClone. Please use a different browser."
         );

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -5924,7 +5924,7 @@ class Store {
 
       const gauges = pairs.filter(hasGauge);
 
-      if (!("structuredCline" in window)) {
+      if (typeof window.structuredClone === "undefined") {
         throw new Error(
           "Your browser does not support structuredClone. Please use a different browser."
         );

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -5922,14 +5922,19 @@ class Store {
           "Error getting veToken and govToken in getRewardBalances"
         );
 
-      const filteredPairs = [...pairs.filter(hasGauge)];
+      const gauges = pairs.filter(hasGauge);
 
-      const filteredPairs2 = [...pairs.filter(hasGauge)];
+      if (typeof window.structuredClone === "undefined") {
+        throw new Error(
+          "Your browser does not support structuredClone. Please use a different browser."
+        );
+      }
 
-      const x_filteredPairs = [...pairs.filter(hasGauge)];
+      const filteredPairs = structuredClone(gauges);
+      const x_filteredPairs = structuredClone(gauges);
+      const filteredPairs2 = structuredClone(gauges);
 
       let veDistReward: VeDistReward[] = [];
-
       let filteredBribes: Gauge[] = []; // Pair with gauge rewardType set to "Bribe"
       let x_filteredBribes: Gauge[] = []; // Pair with gauge rewardType set to "XBribe"
 
@@ -5998,11 +6003,7 @@ class Store {
 
         filteredBribes = filteredPairs
           .filter((pair) => {
-            if (
-              pair.gauge &&
-              pair.gauge.bribesEarned &&
-              pair.gauge.bribesEarned.length > 0
-            ) {
+            if (pair.gauge.bribesEarned && pair.gauge.bribesEarned.length > 0) {
               let shouldReturn = false;
 
               for (let i = 0; i < pair.gauge.bribesEarned.length; i++) {
@@ -6030,7 +6031,6 @@ class Store {
         x_filteredBribes = x_filteredPairs
           .filter((pair) => {
             if (
-              pair.gauge &&
               pair.gauge.x_bribesEarned &&
               pair.gauge.x_bribesEarned.length > 0
             ) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the rewards and gauge filtering logic in the `ssRewards` and `stableSwapStore` components. 

### Detailed summary
- Rewards are now split into `xBribes`, `bribes`, `rewards`, and `veDist`
- `structuredClone` is now used instead of `filter` for gauges
- `filteredBribes` and `x_filteredBribes` now filter out pairs without `bribesEarned` or `x_bribesEarned` fields, respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->