### PR TITLE
change sort method

### DIFF
--- a/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
@@ -121,7 +121,7 @@ function EnhancedTableHead(props: {
           >
             <TableSortLabel
               active={orderBy === headCell.id}
-              direction={orderBy === headCell.id ? order : "asc"}
+              direction={orderBy === headCell.id ? order : "desc"}
               onClick={createSortHandler(headCell.id)}
             >
               <Typography variant="h5" className="text-xs font-extralight">
@@ -402,8 +402,11 @@ export default function EnhancedTable({ pairs }: PairsTableProps) {
     _e: React.MouseEvent<unknown>,
     property: OrderBy
   ) => {
-    const isAsc = orderBy === property && order === "asc";
-    setOrder(isAsc ? "desc" : "asc");
+    if (orderBy === property) {
+      setOrder(order === "asc" ? "desc" : "asc");
+    } else {
+      setOrder("desc");
+    }
     setOrderBy(property);
   };
 


### PR DESCRIPTION
Currently the table was sorted descending by `My Staked Amount` field.

Now if I want to sort any other fields descending, e.g., `TVL`, or `APR`, I would have to click that table head twice.

In this pull request, all fields will be sorted descending on first click instead of twice, which I believe would be the most common use case.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the sorting functionality in `ssLiquidityPairsTable.tsx`. 

### Detailed summary
- Changes the default sort direction from "asc" to "desc"
- Updates the sorting direction when the same column header is clicked multiple times
- Improves code readability and maintainability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->