### PR TITLE
fix for the moment when we couldn't stake right after we created gauge

### DIFF
--- a/Frontend-v1-Original/components/ssLiquidityManage/ssLiquidityManage.tsx
+++ b/Frontend-v1-Original/components/ssLiquidityManage/ssLiquidityManage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import {
   Paper,
@@ -112,14 +112,14 @@ export default function LiquidityManage() {
       );
       setPair(pp);
 
-      if (pp) {
+      if (pp && isBaseAsset(pp.token0) && isBaseAsset(pp.token1)) {
         setWithdrawAsset(pp);
         setAsset0(pp.token0);
         setAsset1(pp.token1);
         setStable(pp.isStable);
       }
 
-      if (pp && BigNumber(pp.balance).gt(0)) {
+      if (pp && pp.balance && BigNumber(pp.balance).gt(0)) {
         setAdvanced(true);
       }
     } else {

--- a/Frontend-v1-Original/stores/abis/abis.ts
+++ b/Frontend-v1-Original/stores/abis/abis.ts
@@ -6,6 +6,7 @@ import { routerABI } from "./routerABI";
 import { voterABI } from "./voterABI";
 import { gaugeABI } from "./gaugeABI";
 import { bribeABI } from "./bribeABI";
+import { bribeFactoryABI } from "./bribeFactoryABI";
 import { tokenABI } from "./tokenABI";
 import { veDistABI } from "./veDistABI";
 import { minterABI } from "./minterABI";
@@ -22,6 +23,7 @@ export default {
   routerABI,
   voterABI,
   bribeABI,
+  bribeFactoryABI,
   gaugeABI,
   veDistABI,
   tokenABI,

--- a/Frontend-v1-Original/stores/abis/bribeFactoryABI.ts
+++ b/Frontend-v1-Original/stores/abis/bribeFactoryABI.ts
@@ -1,0 +1,54 @@
+export const bribeFactoryABI = [
+  {
+    type: "constructor",
+    stateMutability: "nonpayable",
+    inputs: [
+      { type: "address", name: "_voter", internalType: "address" },
+      { type: "uint256", name: "_csrNftId", internalType: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    stateMutability: "view",
+    outputs: [{ type: "address", name: "", internalType: "address" }],
+    name: "TURNSTILE",
+    inputs: [],
+  },
+  {
+    type: "function",
+    stateMutability: "nonpayable",
+    outputs: [{ type: "address", name: "", internalType: "address" }],
+    name: "createBribe",
+    inputs: [
+      { type: "address", name: "existing_bribe", internalType: "address" },
+    ],
+  },
+  {
+    type: "function",
+    stateMutability: "view",
+    outputs: [{ type: "uint256", name: "", internalType: "uint256" }],
+    name: "csrNftId",
+    inputs: [],
+  },
+  {
+    type: "function",
+    stateMutability: "view",
+    outputs: [{ type: "address", name: "", internalType: "address" }],
+    name: "last_bribe",
+    inputs: [],
+  },
+  {
+    type: "function",
+    stateMutability: "view",
+    outputs: [{ type: "address", name: "", internalType: "address" }],
+    name: "oldBribeToNew",
+    inputs: [{ type: "address", name: "", internalType: "address" }],
+  },
+  {
+    type: "function",
+    stateMutability: "view",
+    outputs: [{ type: "address", name: "", internalType: "address" }],
+    name: "voter",
+    inputs: [],
+  },
+] as const;

--- a/Frontend-v1-Original/stores/constants/contracts.ts
+++ b/Frontend-v1-Original/stores/constants/contracts.ts
@@ -49,6 +49,10 @@ export const ERC20_ABI = abis.erc20ABI;
 export const PAIR_ABI = abis.pairABI;
 export const GAUGE_ABI = abis.gaugeABI;
 export const BRIBE_ABI = abis.bribeABI;
+export const BRIBE_FACTORY_ABI = abis.bribeFactoryABI;
+export const WXB_ADDRESS = "0xEA9E24a2979D4ACbdB4CCE6608F6C45F9c4421d7";
+export const X_WXB_ADDRESS = "0xabd64fCF41469BfD1F5074ba28EeDee4cca0E6a6";
+export const XX_WXB_ADDRESS = "0x1E9C436a3F51b08F7BfAF8410465fCbBf7A0ae1C";
 export const TOKEN_ABI = abis.tokenABI;
 
 export const AUTO_BRIBE_ABI = abis.autoBribeABI;

--- a/Frontend-v1-Original/stores/constants/contractsCanto.ts
+++ b/Frontend-v1-Original/stores/constants/contractsCanto.ts
@@ -54,6 +54,10 @@ export const ERC20_ABI = abis.erc20ABI;
 export const PAIR_ABI = abis.pairABI;
 export const GAUGE_ABI = abis.gaugeABI;
 export const BRIBE_ABI = abis.bribeABI;
+export const BRIBE_FACTORY_ABI = abis.bribeFactoryABI;
+export const WXB_ADDRESS = "0xEA9E24a2979D4ACbdB4CCE6608F6C45F9c4421d7";
+export const X_WXB_ADDRESS = "0xabd64fCF41469BfD1F5074ba28EeDee4cca0E6a6";
+export const XX_WXB_ADDRESS = "0x1E9C436a3F51b08F7BfAF8410465fCbBf7A0ae1C";
 export const TOKEN_ABI = abis.tokenABI;
 
 export const AUTO_BRIBE_ABI = abis.autoBribeABI;

--- a/Frontend-v1-Original/stores/constants/contractsGoerli.ts
+++ b/Frontend-v1-Original/stores/constants/contractsGoerli.ts
@@ -50,6 +50,10 @@ export const ERC20_ABI = abis.erc20ABI;
 export const PAIR_ABI = abis.pairABI;
 export const GAUGE_ABI = abis.gaugeABI;
 export const BRIBE_ABI = abis.bribeABI;
+export const BRIBE_FACTORY_ABI = abis.bribeFactoryABI;
+export const WXB_ADDRESS = "0xEA9E24a2979D4ACbdB4CCE6608F6C45F9c4421d7";
+export const X_WXB_ADDRESS = "0xabd64fCF41469BfD1F5074ba28EeDee4cca0E6a6";
+export const XX_WXB_ADDRESS = "0x1E9C436a3F51b08F7BfAF8410465fCbBf7A0ae1C";
 export const TOKEN_ABI = abis.tokenABI;
 
 export const AUTO_BRIBE_ABI = abis.autoBribeABI;

--- a/Frontend-v1-Original/stores/types/types.ts
+++ b/Frontend-v1-Original/stores/types/types.ts
@@ -45,7 +45,7 @@ interface VestNFT {
 }
 
 interface Bribe {
-  token: RouteAsset;
+  token: RouteAsset | BaseAsset;
   reward_ammount: number;
   rewardAmmount: number;
   rewardAmount?: number; // gets assigned in frontend store and eq rewardAmmount
@@ -85,13 +85,11 @@ interface Pair {
     address: `0x${string}`;
     total_supply: number;
     bribe_address: `0x${string}`;
-    fees_address: `0x${string}`;
     wrapped_bribe_address: `0x${string}`;
     x_wrapped_bribe_address: `0x${string}`;
     xx_wrapped_bribe_address: `0x${string}`;
     reward: number;
     bribeAddress: `0x${string}`;
-    feesAddress: `0x${string}`;
     totalSupply: number | string; //gets reassigned to string in frontend store
     bribes: Bribe[];
     x_bribes: Bribe[];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new ABI and constants to the frontend, updates the `types.ts` file, and makes changes to the `ssLiquidityManage.tsx` and `stableSwapStore.ts` files.

### Detailed summary
- Added `bribeFactoryABI.ts` file
- Updated `contracts.ts`, `contractsCanto.ts`, and `contractsGoerli.ts` with `BRIBE_FACTORY_ABI` and new addresses
- Updated `types.ts` with `BaseAsset` type and changed `token` property of `Bribe` type to accept `BaseAsset`
- Updated `ssLiquidityManage.tsx` to only set state if `pp` and `balance` are truthy
- Updated `stableSwapStore.ts` with additional properties for `Pair` and `Gauge` types, and added null check for `getPairByAddress()` call in `_getStakeAllowance()` method

> The following files were skipped due to too many changes: `Frontend-v1-Original/stores/stableSwapStore.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->