### PR TITLE
add link to dexscreener

### DIFF
--- a/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
+++ b/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
@@ -403,7 +403,14 @@ const VotesRow = memo(function VotesRow({
             </div>
             <div>
               <Typography variant="h2" className="text-xs font-extralight">
-                {row.symbol}
+                <a
+                  href={`https://dexscreener.com/canto/${row.address}`}
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                  className="hover:underline"
+                >
+                  {row.symbol}
+                </a>
               </Typography>
               <Typography
                 variant="h5"


### PR DESCRIPTION
Just realized I missed the link in https://github.com/Velocimeter/frontend/pull/90

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a hyperlink to a symbol in a table in `ssVotesTable.tsx`. 

### Detailed summary
- Adds a hyperlink to `row.symbol` in a `Typography` component
- The hyperlink opens in a new tab and leads to `https://dexscreener.com/canto/${row.address}`
- The hyperlink has the class `hover:underline` and `rel="noopener noreferrer nofollow"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->