### PR TITLE
add tvl column for vote page

### DIFF
--- a/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
@@ -1279,7 +1279,7 @@ function stableSort(array: Pair[], comparator: (_a: Pair, _b: Pair) => number) {
   return stabilizedThis.map((el) => el[0]);
 }
 
-function formatTVL(dataNumber: number) {
+export function formatTVL(dataNumber: number) {
   if (dataNumber < 1_000) {
     return "< $1k";
   } else if (dataNumber < 1_000_000) {

--- a/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
+++ b/Frontend-v1-Original/components/ssVotes/ssVotesTable.tsx
@@ -29,10 +29,17 @@ import {
 import { formatCurrency } from "../../utils/utils";
 import { Gauge, Vote, VestNFT } from "../../stores/types/types";
 import tokens from "../../tokens.json";
+import { formatTVL } from "../ssLiquidityPairs/ssLiquidityPairsTable";
 
 const headCells = [
   { id: "expand", numeric: false, disablePadding: true, label: "" },
   { id: "asset", numeric: false, disablePadding: false, label: "Asset" },
+  {
+    id: "tvl",
+    numeric: true,
+    disablePadding: false,
+    label: "TVL",
+  },
   {
     id: "totalVotes",
     numeric: true,
@@ -415,6 +422,10 @@ const VotesRow = memo(function VotesRow({
             </div>
           </div>
         </TableCell>
+        {/* insert tvl */}
+        <TableCell align="right">
+          {!!row.tvl ? formatTVL(row.tvl) : 0}
+        </TableCell>
         <TableCell align="right">
           {!!row.gauge.weight && !!row.gauge.weightPercent ? (
             <>
@@ -685,6 +696,15 @@ function descendingComparator(
         return -1;
       }
       if (caseB > caseA) {
+        return 1;
+      }
+      return 0;
+
+    case "tvl":
+      if (BigNumber(b.tvl).lt(a.tvl)) {
+        return -1;
+      }
+      if (BigNumber(b.tvl).gt(a.tvl)) {
         return 1;
       }
       return 0;


### PR DESCRIPTION
Voters should make informed decision when voting, and tvl number is important as it will affect the APR when voters decide to sell right after claiming.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new column to the `ssVotesTable` component displaying the TVL of each asset. It also exports the `formatTVL` function from `ssLiquidityPairsTable`.

### Detailed summary
- Import `formatTVL` from `ssLiquidityPairsTable`
- Add new column `TVL` to `ssVotesTable`
- Display TVL data using `formatTVL` function
- Add `tvl` case to `descendingComparator` for sorting TVL column

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->