### PR TITLE
fix row data

### DIFF
--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -354,7 +354,7 @@ export default function EnhancedTable({
                             <Close className="fill-red-500" />
                           )}
                         </Typography>
-                        {row.reset && Number(row.lastVoted) !== 0 ? (
+                        {row.reset ? (
                           <Typography
                             variant="h5"
                             className="text-xs font-extralight"

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -328,13 +328,15 @@ export default function EnhancedTable({
                             <Close className="fill-red-500" />
                           )}
                         </Typography>
-                        {Number(row.lastVoted) !== 0 ? (
+                        {row.actionedInCurrentEpoch &&
+                        !row.reset &&
+                        Number(row.lastVoted) !== 0 ? (
                           <Typography
                             variant="h5"
                             className="text-xs font-extralight"
                             color="textSecondary"
                           >
-                            Last voted:{" "}
+                            Voted on:{" "}
                             {new Date(
                               Number(row.lastVoted) * 1000
                             ).toLocaleString()}
@@ -352,6 +354,18 @@ export default function EnhancedTable({
                             <Close className="fill-red-500" />
                           )}
                         </Typography>
+                        {row.reset && Number(row.lastVoted) !== 0 ? (
+                          <Typography
+                            variant="h5"
+                            className="text-xs font-extralight"
+                            color="textSecondary"
+                          >
+                            Reset on:{" "}
+                            {new Date(
+                              Number(row.lastVoted) * 1000
+                            ).toLocaleString()}
+                          </Typography>
+                        ) : null}
                       </TableCell>
                       <TableCell align="right">
                         <Typography


### PR DESCRIPTION
`reset` would also set the `lastVoted` value just like `vote`, it would make more sense showing it as `Reset on:` instead of `Last Voted` under `Voted This Epoch` column.

1. is it voted this epoch? yes, then show when.
2. is it reset this epoch? yes, then show when.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new feature to the `ssVestsTable` component, displaying the date of a reset action if applicable.

### Detailed summary
- Added a new condition to display the reset date in the `ssVestsTable` component.
- If `row.reset` is true, a new `Typography` component is rendered with the reset date.
- The reset date is obtained from the `lastVoted` property of the `row` object and formatted using `toLocaleString()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->