### PR TITLE
show influence column for vest page

### DIFF
--- a/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
+++ b/Frontend-v1-Original/components/ssRewards/ssRewards.tsx
@@ -30,6 +30,7 @@ const initialEmptyToken: VestNFT = {
   actionedInCurrentEpoch: false,
   reset: false,
   lastVoted: BigInt(0),
+  influence: 0,
 };
 
 export default function Rewards() {

--- a/Frontend-v1-Original/components/ssVest/existingLock.tsx
+++ b/Frontend-v1-Original/components/ssVest/existingLock.tsx
@@ -39,6 +39,7 @@ export default function ExistingLock({
         actionedInCurrentEpoch: nft.actionedInCurrentEpoch,
         reset: nft.reset,
         lastVoted: nft.lastVoted,
+        influence: nft.influence,
       };
 
       setFutureNFT(tmpNFT);
@@ -53,6 +54,7 @@ export default function ExistingLock({
       actionedInCurrentEpoch: nft.actionedInCurrentEpoch,
       reset: nft.reset,
       lastVoted: nft.lastVoted,
+      influence: nft.influence,
     };
 
     const now = moment();
@@ -77,6 +79,7 @@ export default function ExistingLock({
       actionedInCurrentEpoch: nft.actionedInCurrentEpoch,
       reset: nft.reset,
       lastVoted: nft.lastVoted,
+      influence: nft.influence,
     };
 
     const now = moment();

--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -286,6 +286,7 @@ export default function Lock({
       actionedInCurrentEpoch: false,
       reset: false,
       lastVoted: BigInt(0),
+      influence: 0,
     };
 
     return (

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -16,9 +16,20 @@ import {
   Grid,
   Tooltip,
   Alert,
+  Menu,
+  MenuItem,
 } from "@mui/material";
 import { useRouter } from "next/router";
-import { EnhancedEncryptionOutlined, Check, Close } from "@mui/icons-material";
+import {
+  EnhancedEncryptionOutlined,
+  Check,
+  Close,
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+  RestartAlt,
+  Merge,
+  BatteryCharging90,
+} from "@mui/icons-material";
 import moment from "moment";
 import BigNumber from "bignumber.js";
 import Link from "next/link";
@@ -59,6 +70,12 @@ const headCells = [
     numeric: true,
     disablePadding: false,
     label: "Vest Expires",
+  },
+  {
+    id: "Influence",
+    numeric: true,
+    disablePadding: false,
+    label: "Share of Total Votes",
   },
   {
     id: "",
@@ -255,7 +272,10 @@ export default function EnhancedTable({
         elevation={0}
         className="flex w-full flex-col items-end border border-[rgba(104,108,122,0.25)]"
       >
-        <Alert severity="info" className="w-full">
+        <Alert
+          severity="info"
+          className="w-full rounded-br-none rounded-bl-none"
+        >
           You can either vote or reset in the same epoch, but not both. NFTs
           voted in the past will have to be reset first to merge.
         </Alert>
@@ -277,201 +297,16 @@ export default function EnhancedTable({
                   if (!row) {
                     return null;
                   }
-                  const labelId = `enhanced-table-checkbox-${index}`;
-
                   return (
-                    <TableRow
-                      key={labelId}
-                      className="hover:bg-[rgba(104,108,122,0.05)]"
-                    >
-                      <TableCell>
-                        <div className="flex items-center">
-                          <div className="relative flex h-9 w-[70px]">
-                            <img
-                              className="absolute left-0 top-0 rounded-[30px]"
-                              src={govToken?.logoURI || undefined}
-                              width="35"
-                              height="35"
-                              alt=""
-                              onError={(e) => {
-                                (e.target as HTMLImageElement).onerror = null;
-                                (e.target as HTMLImageElement).src =
-                                  "/tokens/unknown-logo.png";
-                              }}
-                            />
-                          </div>
-                          <div>
-                            <Typography
-                              variant="h2"
-                              className="text-xs font-extralight"
-                            >
-                              {row.id}
-                            </Typography>
-                            <Typography
-                              variant="h5"
-                              className="text-xs font-extralight"
-                              color="textSecondary"
-                            >
-                              NFT ID
-                            </Typography>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="h2"
-                          className="text-xs font-extralight"
-                        >
-                          {row.actionedInCurrentEpoch && !row.reset ? (
-                            <Check className="fill-green-500" />
-                          ) : (
-                            <Close className="fill-red-500" />
-                          )}
-                        </Typography>
-                        {row.actionedInCurrentEpoch &&
-                        !row.reset &&
-                        Number(row.lastVoted) !== 0 ? (
-                          <Typography
-                            variant="h5"
-                            className="text-xs font-extralight"
-                            color="textSecondary"
-                          >
-                            Voted on:{" "}
-                            {new Date(
-                              Number(row.lastVoted) * 1000
-                            ).toLocaleString()}
-                          </Typography>
-                        ) : null}
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="h2"
-                          className="text-xs font-extralight"
-                        >
-                          {row.reset ? (
-                            <Check className="fill-green-500" />
-                          ) : (
-                            <Close className="fill-red-500" />
-                          )}
-                        </Typography>
-                        {row.reset ? (
-                          <Typography
-                            variant="h5"
-                            className="text-xs font-extralight"
-                            color="textSecondary"
-                          >
-                            Reset on:{" "}
-                            {new Date(
-                              Number(row.lastVoted) * 1000
-                            ).toLocaleString()}
-                          </Typography>
-                        ) : null}
-                      </TableCell>
-                      <TableCell align="right">
-                        <Typography
-                          variant="h2"
-                          className="text-xs font-extralight"
-                        >
-                          {formatCurrency(row.lockAmount)}
-                        </Typography>
-                        <Typography
-                          variant="h5"
-                          className="text-xs font-extralight"
-                          color="textSecondary"
-                        >
-                          {govToken?.symbol}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="right">
-                        <Typography
-                          variant="h2"
-                          className="text-xs font-extralight"
-                        >
-                          {formatCurrency(row.lockValue)}
-                        </Typography>
-                        <Typography
-                          variant="h5"
-                          className="text-xs font-extralight"
-                          color="textSecondary"
-                        >
-                          {veToken?.symbol}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="right">
-                        <Typography
-                          variant="h2"
-                          className="text-xs font-extralight"
-                        >
-                          {moment.unix(+row.lockEnds).format("YYYY-MM-DD")}
-                        </Typography>
-                        <Typography
-                          variant="h5"
-                          className="text-xs font-extralight"
-                          color="textSecondary"
-                        >
-                          Expires {moment.unix(+row.lockEnds).fromNow()}
-                        </Typography>
-                      </TableCell>
-                      <TableCell
-                        align="right"
-                        className="flex flex-col space-y-2 lg:flex-row lg:justify-end lg:space-y-0 lg:space-x-2"
-                      >
-                        {!row.actionedInCurrentEpoch ? (
-                          <Tooltip
-                            title={
-                              <div>
-                                Reset to transfer, sell or merge NFT.
-                                <br />
-                                Reset disables voting until next epoch.
-                              </div>
-                            }
-                            placement="right"
-                            enterTouchDelay={500}
-                          >
-                            <Button
-                              variant="outlined"
-                              color="primary"
-                              onClick={() => {
-                                onReset(row);
-                              }}
-                            >
-                              Reset
-                            </Button>
-                          </Tooltip>
-                        ) : (
-                          <Button variant="outlined" color="primary" disabled>
-                            Reset
-                          </Button>
-                        )}
-                        {/*
-                        1. last voted is 0, i.e., totally new nft
-                        2. actioned in current epoch, and that action is reset
-                         */}
-                        {Number(row.lastVoted) === 0 ||
-                        (row.actionedInCurrentEpoch && row.reset) ? (
-                          <Link href={`/vest/${row.id}/merge`}>
-                            <Button variant="outlined" color="primary">
-                              Merge
-                            </Button>
-                          </Link>
-                        ) : (
-                          <Tooltip title="">
-                            <Button variant="outlined" color="primary" disabled>
-                              Merge
-                            </Button>
-                          </Tooltip>
-                        )}
-                        <Button
-                          variant="outlined"
-                          color="primary"
-                          onClick={() => {
-                            onView(row);
-                          }}
-                        >
-                          Manage
-                        </Button>
-                      </TableCell>
-                    </TableRow>
+                    <MyTableRow
+                      key={row.id}
+                      row={row}
+                      index={index}
+                      govToken={govToken}
+                      veToken={veToken}
+                      onReset={onReset}
+                      onView={onView}
+                    />
                   );
                 })}
             </TableBody>
@@ -488,6 +323,225 @@ export default function EnhancedTable({
         />
       </Paper>
     </div>
+  );
+}
+
+function MyTableRow(props: {
+  row: VestNFT;
+  index: number;
+  govToken: GovToken | null;
+  veToken: VeToken | null;
+  onReset: any;
+  onView: any;
+}) {
+  const { row, index, govToken, veToken, onReset, onView } = props;
+  const influence =
+    row.influence * 100 > 0.001
+      ? `${(row.influence * 100).toFixed(3)}%`
+      : "<0.001%";
+  const labelId = `enhanced-table-checkbox-${index}`;
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <TableRow key={labelId} className="hover:bg-[rgba(104,108,122,0.05)]">
+      <TableCell>
+        <div className="flex items-center">
+          <div className="relative flex h-9 w-[70px]">
+            <img
+              className="absolute left-0 top-0 rounded-[30px]"
+              src={govToken?.logoURI || undefined}
+              width="35"
+              height="35"
+              alt=""
+              onError={(e) => {
+                (e.target as HTMLImageElement).onerror = null;
+                (e.target as HTMLImageElement).src = "/tokens/unknown-logo.png";
+              }}
+            />
+          </div>
+          <div>
+            <Typography variant="h2" className="text-xs font-extralight">
+              {row.id}
+            </Typography>
+            <Typography
+              variant="h5"
+              className="text-xs font-extralight"
+              color="textSecondary"
+            >
+              NFT ID
+            </Typography>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Typography variant="h2" className="text-xs font-extralight">
+          {row.actionedInCurrentEpoch && !row.reset ? (
+            <Check className="fill-green-500" />
+          ) : (
+            <Close className="fill-red-500" />
+          )}
+        </Typography>
+        {row.actionedInCurrentEpoch &&
+        !row.reset &&
+        Number(row.lastVoted) !== 0 ? (
+          <Typography
+            variant="h5"
+            className="text-xs font-extralight"
+            color="textSecondary"
+          >
+            Voted on: {new Date(Number(row.lastVoted) * 1000).toLocaleString()}
+          </Typography>
+        ) : null}
+        {/* show last voted so users can tell to reset or not */}
+        {!row.actionedInCurrentEpoch && Number(row.lastVoted) !== 0 ? (
+          <Typography
+            variant="h5"
+            className="text-xs font-extralight"
+            color="textSecondary"
+          >
+            Last Voted:{" "}
+            {new Date(Number(row.lastVoted) * 1000).toLocaleString()}
+          </Typography>
+        ) : null}
+      </TableCell>
+      <TableCell>
+        <Typography variant="h2" className="text-xs font-extralight">
+          {row.reset ? (
+            <Check className="fill-green-500" />
+          ) : (
+            <Close className="fill-red-500" />
+          )}
+        </Typography>
+        {row.reset ? (
+          <Typography
+            variant="h5"
+            className="text-xs font-extralight"
+            color="textSecondary"
+          >
+            Reset on: {new Date(Number(row.lastVoted) * 1000).toLocaleString()}
+          </Typography>
+        ) : null}
+      </TableCell>
+      <TableCell align="right">
+        <Typography variant="h2" className="text-xs font-extralight">
+          {formatCurrency(row.lockAmount)}
+        </Typography>
+        <Typography
+          variant="h5"
+          className="text-xs font-extralight"
+          color="textSecondary"
+        >
+          {govToken?.symbol}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        <Typography variant="h2" className="text-xs font-extralight">
+          {formatCurrency(row.lockValue)}
+        </Typography>
+        <Typography
+          variant="h5"
+          className="text-xs font-extralight"
+          color="textSecondary"
+        >
+          {veToken?.symbol}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        <Typography variant="h2" className="text-xs font-extralight">
+          {moment.unix(+row.lockEnds).format("YYYY-MM-DD")}
+        </Typography>
+        <Typography
+          variant="h5"
+          className="text-xs font-extralight"
+          color="textSecondary"
+        >
+          Expires {moment.unix(+row.lockEnds).fromNow()}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        <Tooltip title={`${(row.influence * 100).toFixed(7)}%`}>
+          <Typography variant="h2" className="text-xs font-extralight">
+            {influence}
+          </Typography>
+        </Tooltip>
+      </TableCell>
+      <TableCell
+        align="right"
+        className="flex flex-col space-y-2 lg:flex-row lg:justify-end lg:space-y-0 lg:space-x-2"
+      >
+        <Button
+          variant="outlined"
+          color="primary"
+          endIcon={open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+          onClick={handleClick}
+        >
+          Menu
+        </Button>
+        <Menu
+          sx={{
+            "& .MuiPaper-root": {
+              minWidth: "150px",
+            },
+          }}
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          elevation={0}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "right",
+          }}
+          transformOrigin={{
+            vertical: "top",
+            horizontal: "right",
+          }}
+        >
+          <MenuItem
+            disableRipple
+            disabled={row.actionedInCurrentEpoch}
+            onClick={() => {
+              handleClose();
+              onReset(row);
+            }}
+          >
+            <RestartAlt className="mr-2" /> <span>Reset</span>
+          </MenuItem>
+          {/*
+      1. last voted is 0, i.e., totally new nft
+      2. actioned in current epoch, and that action is reset
+       */}
+          <MenuItem
+            disableRipple
+            disabled={
+              !(
+                Number(row.lastVoted) === 0 ||
+                (row.actionedInCurrentEpoch && row.reset)
+              )
+            }
+          >
+            <Link
+              href={`/vest/${row.id}/merge`}
+              className="flex items-center space-x-2"
+            >
+              <>
+                <Merge className="mr-2" /> <span>Merge</span>
+              </>
+            </Link>
+          </MenuItem>
+          <MenuItem disableRipple onClick={() => onView(row)}>
+            <BatteryCharging90 className="mr-2" /> Extend
+          </MenuItem>
+        </Menu>
+      </TableCell>
+    </TableRow>
   );
 }
 

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -28,7 +28,7 @@ import {
   KeyboardArrowUp,
   RestartAlt,
   Merge,
-  BatteryCharging90,
+  TrendingUp,
 } from "@mui/icons-material";
 import moment from "moment";
 import BigNumber from "bignumber.js";
@@ -537,7 +537,7 @@ function MyTableRow(props: {
             </Link>
           </MenuItem>
           <MenuItem disableRipple onClick={() => onView(row)}>
-            <BatteryCharging90 className="mr-2" /> Extend
+            <TrendingUp className="mr-2" /> Manage
           </MenuItem>
         </Menu>
       </TableCell>

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -75,7 +75,7 @@ const headCells = [
     id: "Influence",
     numeric: true,
     disablePadding: false,
-    label: "Share of Total Votes",
+    label: "Voting Power",
   },
   {
     id: "",

--- a/Frontend-v1-Original/components/ssVotes/ssVotes.tsx
+++ b/Frontend-v1-Original/components/ssVotes/ssVotes.tsx
@@ -42,6 +42,7 @@ const initialEmptyToken: VestNFT = {
   actionedInCurrentEpoch: false,
   reset: false,
   lastVoted: BigInt(0),
+  influence: 0,
 };
 
 function MyListSubheader(props: ListSubheaderProps) {

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -314,7 +314,7 @@ class Store {
             functionName: "tokenOfOwnerByIndex",
             args: [address, BigInt(idx)],
           });
-          const [[lockedAmount, lockedEnd], lockValue, voted] =
+          const [[lockedAmount, lockedEnd], lockValue, voted, totalSupply] =
             await viemClient.multicall({
               allowFailure: false,
               multicallAddress: CONTRACTS.MULTICALL_ADDRESS,
@@ -334,6 +334,10 @@ class Store {
                   functionName: "voted",
                   args: [tokenIndex],
                 },
+                {
+                  ...vestingContract,
+                  functionName: "totalSupply",
+                },
               ],
             });
 
@@ -348,6 +352,9 @@ class Store {
             actionedInCurrentEpoch,
             reset: actionedInCurrentEpoch && !voted,
             lastVoted,
+            influence:
+              Number(formatUnits(lockValue, veToken.decimals)) /
+              Number(formatUnits(totalSupply, veToken.decimals)),
           };
         })
       );
@@ -404,7 +411,7 @@ class Store {
         args: [account, BigInt(id)],
       });
 
-      const [[lockedAmount, lockedEnd], lockValue, voted] =
+      const [[lockedAmount, lockedEnd], lockValue, voted, totalSupply] =
         await viemClient.multicall({
           allowFailure: false,
           multicallAddress: CONTRACTS.MULTICALL_ADDRESS,
@@ -424,6 +431,10 @@ class Store {
               functionName: "voted",
               args: [tokenIndex],
             },
+            {
+              ...vestingContract,
+              functionName: "totalSupply",
+            },
           ],
         });
 
@@ -440,6 +451,9 @@ class Store {
             actionedInCurrentEpoch,
             reset: actionedInCurrentEpoch && !voted,
             lastVoted,
+            influence:
+              Number(formatUnits(lockValue, veToken.decimals)) /
+              Number(formatUnits(totalSupply, veToken.decimals)),
           };
         }
 
@@ -1652,7 +1666,7 @@ class Store {
             functionName: "tokenOfOwnerByIndex",
             args: [address, BigInt(idx)],
           });
-          const [[lockedAmount, lockedEnd], lockValue, voted] =
+          const [[lockedAmount, lockedEnd], lockValue, voted, totalSupply] =
             await viemClient.multicall({
               allowFailure: false,
               multicallAddress: CONTRACTS.MULTICALL_ADDRESS,
@@ -1672,6 +1686,10 @@ class Store {
                   functionName: "voted",
                   args: [tokenIndex],
                 },
+                {
+                  ...vestingContract,
+                  functionName: "totalSupply",
+                },
               ],
             });
 
@@ -1687,6 +1705,9 @@ class Store {
             actionedInCurrentEpoch,
             reset: actionedInCurrentEpoch && !voted,
             lastVoted,
+            influence:
+              Number(formatUnits(lockValue, veToken.decimals)) /
+              Number(formatUnits(totalSupply, veToken.decimals)),
           };
         })
       );
@@ -4134,7 +4155,7 @@ class Store {
             args: [account, BigInt(idx)] as const,
           });
 
-          const [[lockedAmount, lockedEnd], lockValue, voted] =
+          const [[lockedAmount, lockedEnd], lockValue, voted, totalSupply] =
             await viemClient.multicall({
               allowFailure: false,
               multicallAddress: CONTRACTS.MULTICALL_ADDRESS,
@@ -4154,6 +4175,10 @@ class Store {
                   functionName: "voted",
                   args: [tokenIndex],
                 },
+                {
+                  ...vestingContract,
+                  functionName: "totalSupply",
+                },
               ],
             });
 
@@ -4169,6 +4194,9 @@ class Store {
             actionedInCurrentEpoch,
             reset: actionedInCurrentEpoch && !voted,
             lastVoted,
+            influence:
+              Number(formatUnits(lockValue, veToken.decimals)) /
+              Number(formatUnits(totalSupply, veToken.decimals)),
           };
         })
       );

--- a/Frontend-v1-Original/stores/types/types.ts
+++ b/Frontend-v1-Original/stores/types/types.ts
@@ -42,6 +42,7 @@ interface VestNFT {
   actionedInCurrentEpoch: boolean;
   reset: boolean;
   lastVoted: bigint;
+  influence: number;
 }
 
 interface Bribe {


### PR DESCRIPTION
The purpose the influence is to help track my share of the total votes. Currently I had to do the math manually myself.

Since there's another column introduced, I would like to combine all the action buttons into one menu so they don't take too much space. And we might include more actions in future like `transfer`ing nfts.

<img width="528" alt="" src="https://github.com/Velocimeter/frontend/assets/126733611/d9ce0858-58b9-4130-841e-cf7241f8a183">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `influence` field to the vesting NFTs and displays it in the vesting table. It also includes various code changes related to this feature.

### Detailed summary
- Added `influence` field to vesting NFTs
- Display `influence` in vesting table
- Various code changes related to `influence` feature

> The following files were skipped due to too many changes: `Frontend-v1-Original/components/ssVests/ssVestsTable.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->