### PR TITLE
fix issue #101

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -26,7 +26,7 @@ export const lockOptions: {
   "1 year": 365,
   "2 years": 730,
   "3 years": 1095,
-  "4 years": 1461,
+  "4 years": 1460,
 };
 export default function LockDuration({
   nft,


### PR DESCRIPTION
Closes https://github.com/Velocimeter/frontend/issues/101

Not sure why `4 years` was `1461` before which can be traced back to https://github.com/Velocimeter/frontend/blame/e1846f78a072573f9f4c718a470036128297217a/Frontend-v1-Original/components/ssVest/lockDuration.tsx#L85:

![](https://github.com/Velocimeter/frontend/assets/126733611/2248d752-5444-492a-b825-4b1e323bd179)

But I think it might not make sense when 1 year is 365 days? And obviously the contract doesn't take leap year into consideration per https://github.com/Velocimeter/contracts-latest/blob/7d31a8de0b1acc278a34ef7c59a258343f02c19a/contracts/VotingEscrow.sol#L772

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the lock duration values in `lockDuration.tsx` from 1461 to 1460 for 4 years. 

### Detailed summary
- Updated lock duration value for "4 years" from 1461 to 1460 in `lockDuration.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->