### PR TITLE
add oblotr boost info

### DIFF
--- a/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/ssLiquidityPairs/ssLiquidityPairsTable.tsx
@@ -38,6 +38,7 @@ import {
   KeyboardArrowUp,
   KeyboardArrowDown,
   OpenInNewOutlined,
+  LocalFireDepartmentOutlined,
 } from "@mui/icons-material";
 
 import { formatCurrency } from "../../utils/utils";
@@ -1004,37 +1005,31 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
             {formatTVL(row.tvl)}
           </Typography>
         </TableCell>
-        {row && (row.apr !== undefined || row.apr !== null) && (
-          <TableCell align="right">
-            <Grid container spacing={0}>
-              <Grid item lg={10}>
-                <Typography variant="h2" className="text-xs font-extralight">
-                  {row.apr.toFixed(2)}%
-                </Typography>
-              </Grid>
-              {row && row.isAliveGauge === false && (
-                <Grid item lg={2}>
-                  <Tooltip title="Gauge has been killed">
-                    <WarningOutlined className="ml-2 text-base text-yellow-300" />
-                  </Tooltip>
-                </Grid>
-              )}
+        <TableCell align="right">
+          <Grid container spacing={0}>
+            <Grid item lg={10}>
+              <Typography variant="h2" className="text-xs font-extralight">
+                {row.apr.toFixed(2)}%
+              </Typography>
             </Grid>
-          </TableCell>
-        )}
-        {!(row && (row.apr !== undefined || row.apr !== null)) && (
-          <div className="flex items-center justify-end max-md:block">
-            <Skeleton
-              variant="rectangular"
-              width={120}
-              height={16}
-              style={{
-                marginTop: "1px",
-                marginBottom: "1px",
-              }}
-            />
-          </div>
-        )}
+            {row.isAliveGauge === false && (
+              <Grid item lg={2}>
+                <Tooltip title="Gauge has been killed">
+                  <WarningOutlined className="ml-2 text-base text-yellow-300" />
+                </Tooltip>
+              </Grid>
+            )}
+            {row.oblotr_apr > 0 && (
+              <Grid item lg={2}>
+                <Tooltip
+                  title={`oBLOTR APR BOOST ${row.oblotr_apr.toFixed(2)}%`}
+                >
+                  <LocalFireDepartmentOutlined className="ml-2 text-base text-orange-600" />
+                </Tooltip>
+              </Grid>
+            )}
+          </Grid>
+        </TableCell>
         <TableCell align="right">
           <Button
             variant="outlined"
@@ -1170,10 +1165,12 @@ function descendingComparator(a: Pair, b: Pair, orderBy: OrderBy) {
       return 0;
 
     case "apr":
-      if (BigNumber(b?.apr).lt(a?.apr)) {
+      const bApr = b.apr + b.oblotr_apr;
+      const aApr = a.apr + a.oblotr_apr;
+      if (BigNumber(bApr).lt(aApr)) {
         return -1;
       }
-      if (BigNumber(b?.apr).gt(a?.apr)) {
+      if (BigNumber(bApr).gt(aApr)) {
         return 1;
       }
       return 0;

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -689,6 +689,7 @@ class Store {
           local: false,
         },
         apr: 0,
+        oblotr_apr: 0,
         total_supply: 0,
         token0_address: token0,
         token1_address: token1,

--- a/Frontend-v1-Original/stores/types/types.ts
+++ b/Frontend-v1-Original/stores/types/types.ts
@@ -58,6 +58,7 @@ type BribeEarned = { earned: string };
 interface Pair {
   tvl: number;
   apr: number;
+  oblotr_apr: number;
   address: `0x${string}`;
   symbol: string;
   decimals: number;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new feature to the UI that displays an APR boost for certain pairs. 

### Detailed summary
- Added `oblotr_apr` field to `stableSwapStore.ts`
- Added `oblotr_apr` field to `types.ts`
- Added `LocalFireDepartmentOutlined` icon to `ssLiquidityPairsTable.tsx`
- Added tooltip to display `oBLOTR APR BOOST` for pairs with non-zero `oblotr_apr`
- Updated `descendingComparator` function to include `oblotr_apr` in sorting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->