### PR TITLE
fix merge link

### DIFF
--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -250,10 +250,6 @@ export default function EnhancedTable({
     router.push(`/vest/${nft.id}`);
   };
 
-  const onMerge = (nft: VestNFT) => {
-    router.push(`/vest/${nft.id}/merge`);
-  };
-
   const onReset = (nft: {
     lockAmount: string;
     lockValue: string;
@@ -310,7 +306,6 @@ export default function EnhancedTable({
                       veToken={veToken}
                       onReset={onReset}
                       onView={onView}
-                      onMerge={onMerge}
                     />
                   );
                 })}
@@ -338,9 +333,8 @@ function MyTableRow(props: {
   veToken: VeToken | null;
   onReset: any;
   onView: any;
-  onMerge: any;
 }) {
-  const { row, index, govToken, veToken, onMerge, onReset, onView } = props;
+  const { row, index, govToken, veToken, onReset, onView } = props;
   const influence =
     row.influence * 100 > 0.001
       ? `${(row.influence * 100).toFixed(3)}%`
@@ -532,11 +526,15 @@ function MyTableRow(props: {
                 (row.actionedInCurrentEpoch && row.reset)
               )
             }
-            onClick={() => {
-              onMerge(row);
-            }}
           >
-            <Merge className="mr-2" /> <span>Merge</span>
+            <Link
+              href={`/vest/${row.id}/merge`}
+              className="flex items-center space-x-2"
+            >
+              <>
+                <Merge className="mr-2" /> <span>Merge</span>
+              </>
+            </Link>
           </MenuItem>
           <MenuItem disableRipple onClick={() => onView(row)}>
             <TrendingUp className="mr-2" /> Manage

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -250,6 +250,10 @@ export default function EnhancedTable({
     router.push(`/vest/${nft.id}`);
   };
 
+  const onMerge = (nft: VestNFT) => {
+    router.push(`/vest/${nft.id}/merge`);
+  };
+
   const onReset = (nft: {
     lockAmount: string;
     lockValue: string;
@@ -306,6 +310,7 @@ export default function EnhancedTable({
                       veToken={veToken}
                       onReset={onReset}
                       onView={onView}
+                      onMerge={onMerge}
                     />
                   );
                 })}
@@ -333,8 +338,9 @@ function MyTableRow(props: {
   veToken: VeToken | null;
   onReset: any;
   onView: any;
+  onMerge: any;
 }) {
-  const { row, index, govToken, veToken, onReset, onView } = props;
+  const { row, index, govToken, veToken, onMerge, onReset, onView } = props;
   const influence =
     row.influence * 100 > 0.001
       ? `${(row.influence * 100).toFixed(3)}%`
@@ -526,15 +532,11 @@ function MyTableRow(props: {
                 (row.actionedInCurrentEpoch && row.reset)
               )
             }
+            onClick={() => {
+              onMerge(row);
+            }}
           >
-            <Link
-              href={`/vest/${row.id}/merge`}
-              className="flex items-center space-x-2"
-            >
-              <>
-                <Merge className="mr-2" /> <span>Merge</span>
-              </>
-            </Link>
+            <Merge className="mr-2" /> <span>Merge</span>
           </MenuItem>
           <MenuItem disableRipple onClick={() => onView(row)}>
             <TrendingUp className="mr-2" /> Manage

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -531,9 +531,9 @@ function MyTableRow(props: {
               href={`/vest/${row.id}/merge`}
               className="flex items-center space-x-2"
             >
-              <>
+              <a>
                 <Merge className="mr-2" /> <span>Merge</span>
-              </>
+              </a>
             </Link>
           </MenuItem>
           <MenuItem disableRipple onClick={() => onView(row)}>


### PR DESCRIPTION
Seems `Link` inside `MenuItem` is not supported in MUI, and I had to replace it with a `onClick` event.

This is a bug introduced in https://github.com/Velocimeter/frontend/pull/100.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a link to the Merge button in the ssVestsTable component.

### Detailed summary
- Wrapped the Merge button in an anchor tag
- Added a Link component to the anchor tag
- Removed unnecessary empty fragment tags

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->