### PR TITLE
fix lock durations

### DIFF
--- a/Frontend-v1-Original/components/ssVest/existingLock.tsx
+++ b/Frontend-v1-Original/components/ssVest/existingLock.tsx
@@ -9,7 +9,7 @@ import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
 
 import classes from "./ssVest.module.css";
 import LockAmount from "./lockAmount";
-import LockDuration from "./lockDuration";
+import LockDuration, { lockOptions } from "./lockDuration";
 import VestingInfo from "./vestingInfo";
 
 export default function ExistingLock({
@@ -64,7 +64,7 @@ export default function ExistingLock({
     tmpNFT.lockAmount = BigNumber(nft.lockAmount).plus(amount).toFixed(18);
     tmpNFT.lockValue = BigNumber(tmpNFT.lockAmount)
       .times(parseInt(dayToExpire.toString()) + 1)
-      .div(1460)
+      .div(lockOptions["26 weeks"])
       .toFixed(18);
 
     setFutureNFT(tmpNFT);
@@ -89,7 +89,7 @@ export default function ExistingLock({
     tmpNFT.lockEnds = expiry.unix().toString();
     tmpNFT.lockValue = BigNumber(tmpNFT.lockAmount)
       .times(parseInt(dayToExpire.toString()))
-      .div(1460)
+      .div(lockOptions["26 weeks"])
       .toFixed(18);
 
     setFutureNFT(tmpNFT);

--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -10,6 +10,7 @@ import {
   FormControlLabel,
   Tooltip,
   IconButton,
+  Alert,
 } from "@mui/material";
 import { useRouter } from "next/router";
 import BigNumber from "bignumber.js";
@@ -350,6 +351,10 @@ export default function Lock({
           </div>
         </div>
         {renderVestInformation()}
+        <Alert severity="info">
+          All lock will be rounded down to the nearest Thursday at 00:00 UTC, which
+          is the start of the nearest epoch.
+        </Alert>
         <div className={classes.actionsContainer}>
           <Button
             className={classes.buttonOverride}

--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -25,7 +25,7 @@ import { GovToken, VeToken, VestNFT } from "../../stores/types/types";
 import VestingInfo from "./vestingInfo";
 import classes from "./ssVest.module.css";
 
-import { lockOptions } from "./lockDuration";
+import { type LockOption, lockOptions } from "./lockDuration";
 
 export default function Lock({
   govToken,
@@ -41,9 +41,11 @@ export default function Lock({
 
   const [amount, setAmount] = useState("");
   const [amountError, setAmountError] = useState<string | false>(false);
-  const [selectedValue, setSelectedValue] = useState<string | null>("8"); // select 1 week by default
+  const [selectedValue, setSelectedValue] = useState<string | null>(
+    lockOptions["6.5 weeks"] + ""
+  );
   const [selectedDate, setSelectedDate] = useState(
-    moment().add(7, "days").format("YYYY-MM-DD")
+    moment().add(lockOptions["6.5 weeks"], "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
 
@@ -172,8 +174,12 @@ export default function Lock({
               onChange={amountChanged}
               disabled={lockLoading}
               inputProps={{
-                min: moment().add(7, "days").format("YYYY-MM-DD"),
-                max: moment().add(1460, "days").format("YYYY-MM-DD"),
+                min: moment()
+                  .add(lockOptions["6.5 weeks"], "days")
+                  .format("YYYY-MM-DD"),
+                max: moment()
+                  .add(lockOptions["26 weeks"], "days")
+                  .format("YYYY-MM-DD"),
               }}
               InputProps={{
                 className: classes.largeInput,
@@ -280,7 +286,7 @@ export default function Lock({
       lockAmount: amount,
       lockValue: BigNumber(amount)
         .times(parseInt(dayToExpire.toString()) + 1)
-        .div(1460)
+        .div(lockOptions["26 weeks"])
         .toFixed(18),
       lockEnds: expiry.unix().toString(),
       actionedInCurrentEpoch: false,
@@ -333,7 +339,7 @@ export default function Lock({
                   <FormControlLabel
                     key={key}
                     className={classes.vestPeriodLabel}
-                    value={lockOptions[key]}
+                    value={lockOptions[key as LockOption]}
                     control={<Radio color="primary" />}
                     label={key}
                     labelPlacement="end"

--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -25,6 +25,19 @@ export const lockOptions: Record<LockOption, number> = {
   "19.5 weeks": Math.ceil(19.5 * 7),
   "26 weeks": Math.ceil(26 * 7),
 };
+
+/**
+ *
+ * @param date
+ * @returns timestamp of the start of the epoch, i.e., thursday 00:00 UTC
+ */
+function roundDownToWeekBoundary(date: moment.Moment) {
+  const WEEK = 7 * 24 * 60 * 60 * 1000;
+  // convert date to timestamp
+  const timestamp = date.valueOf();
+  return Math.floor(timestamp / WEEK) * WEEK;
+}
+
 export default function LockDuration({
   nft,
   updateLockDuration,
@@ -161,6 +174,9 @@ export default function LockDuration({
     );
   };
 
+  const max = moment().add(lockOptions["26 weeks"], "days");
+  const roundedDownMax = roundDownToWeekBoundary(max);
+  const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
   return (
     <div className={classes.someContainer}>
       <div className={classes.inputsContainer3}>
@@ -195,12 +211,16 @@ export default function LockDuration({
           variant="contained"
           size="large"
           color="primary"
-          disabled={lockLoading}
+          disabled={lockLoading || maxLocked}
           onClick={onLock}
         >
-          <Typography className={classes.actionButtonText}>
-            {lockLoading ? `Increasing Duration` : `Increase Duration`}
-          </Typography>
+          {maxLocked ? (
+            <Typography className="text-gray-600">MAX LOCKED</Typography>
+          ) : (
+            <Typography className={classes.actionButtonText}>
+              {lockLoading ? `Increasing Duration` : `Increase Duration`}
+            </Typography>
+          )}
           {lockLoading && (
             <CircularProgress size={10} className={classes.loadingCircle} />
           )}

--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -18,15 +18,12 @@ import { VestNFT } from "../../stores/types/types";
 
 import classes from "./ssVest.module.css";
 
-export const lockOptions: {
-  [key: string]: number;
-} = {
-  "1 week": 8,
-  "1 month": 30,
-  "1 year": 365,
-  "2 years": 730,
-  "3 years": 1095,
-  "4 years": 1460,
+export type LockOption = "6.5 weeks" | "13 weeks" | "19.5 weeks" | "26 weeks";
+export const lockOptions: Record<LockOption, number> = {
+  "6.5 weeks": Math.ceil(6.5 * 7),
+  "13 weeks": Math.ceil(13 * 7),
+  "19.5 weeks": Math.ceil(19.5 * 7),
+  "26 weeks": Math.ceil(26 * 7),
 };
 export default function LockDuration({
   nft,
@@ -39,7 +36,7 @@ export default function LockDuration({
   const [lockLoading, setLockLoading] = useState(false);
 
   const [selectedDate, setSelectedDate] = useState(
-    moment().add(8, "days").format("YYYY-MM-DD")
+    moment().add(lockOptions["6.5 weeks"], "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
@@ -150,7 +147,9 @@ export default function LockDuration({
               disabled={lockLoading}
               inputProps={{
                 min: min,
-                max: moment().add(1460, "days").format("YYYY-MM-DD"),
+                max: moment()
+                  .add(lockOptions["26 weeks"], "days")
+                  .format("YYYY-MM-DD"),
               }}
               InputProps={{
                 className: classes.largeInput,
@@ -174,11 +173,12 @@ export default function LockDuration({
             value={selectedValue}
           >
             {Object.keys(lockOptions).map((key) => {
+              const value = lockOptions[key as LockOption];
               return (
                 <FormControlLabel
                   key={key}
                   className={classes.vestPeriodLabel}
-                  value={lockOptions[key]}
+                  value={value}
                   control={<Radio color="primary" />}
                   label={key}
                   labelPlacement="end"

--- a/Frontend-v1-Original/components/ssVest/vestingInfo.tsx
+++ b/Frontend-v1-Original/components/ssVest/vestingInfo.tsx
@@ -5,6 +5,7 @@ import { formatCurrency } from "../../utils/utils";
 import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
 
 import classes from "./ssVest.module.css";
+import { lockOptions } from "./lockDuration";
 
 interface VestingInfoProps {
   veToken: VeToken | null;
@@ -85,18 +86,18 @@ export default function VestingInfo({
       )}
       {showVestingStructure && (
         <div className={classes.seccondSection}>
-          <Typography className={classes.info} color="textSecondary">
-            1 {govToken?.symbol} locked for 4 years = 1.00 {veToken?.symbol}
-          </Typography>
-          <Typography className={classes.info} color="textSecondary">
-            1 {govToken?.symbol} locked for 3 years = 0.75 {veToken?.symbol}
-          </Typography>
-          <Typography className={classes.info} color="textSecondary">
-            1 {govToken?.symbol} locked for 2 years = 0.50 {veToken?.symbol}
-          </Typography>
-          <Typography className={classes.info} color="textSecondary">
-            1 {govToken?.symbol} locked for 1 years = 0.25 {veToken?.symbol}
-          </Typography>
+          {Object.entries(lockOptions)
+            .sort((a, b) => a[1] - b[1])
+            .map(([option], index) => (
+              <Typography
+                key={option}
+                className={classes.info}
+                color="textSecondary"
+              >
+                1 {govToken?.symbol} locked for {option} ={" "}
+                {["0.25", "0.5", "0.75", "1.00"][index]} {veToken?.symbol}
+              </Typography>
+            ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
Update lock durations as the max lock was set to 26 weeks in v3.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new lock duration options and updates the lock amount and value calculations accordingly. It also displays the vesting structure in a more user-friendly way and adds a warning about the rounding of lock periods to the nearest Thursday.

### Detailed summary
- Adds new lock duration options: 6.5 weeks, 13 weeks, 19.5 weeks, and 26 weeks
- Updates lock amount and value calculations to use the new duration options
- Displays vesting structure in a more user-friendly way
- Adds a warning about the rounding of lock periods to the nearest Thursday

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->