### PR TITLE
add firebird routing back

### DIFF
--- a/Frontend-v1-Original/components/ssSwap/setup.tsx
+++ b/Frontend-v1-Original/components/ssSwap/setup.tsx
@@ -29,7 +29,12 @@ import {
   W_NATIVE_ADDRESS,
   W_NATIVE_SYMBOL,
 } from "../../stores/constants/constants";
-import type { BaseAsset, LegacyQuote } from "../../stores/types/types";
+import type {
+  BaseAsset,
+  Path,
+  QuoteSwapResponse,
+  FireBirdTokens,
+} from "../../stores/types/types";
 
 function Setup() {
   const [, updateState] = React.useState<{}>();
@@ -60,7 +65,7 @@ function Setup() {
   const [slippageError] = useState(false);
 
   const [quoteError, setQuoteError] = useState<string | null | false>(null);
-  const [quote, setQuote] = useState<LegacyQuote | null>(null);
+  const [quote, setQuote] = useState<QuoteSwapResponse | null>(null);
 
   const [tokenPrices, setTokenPrices] = useState<Map<string, number>>();
 
@@ -115,7 +120,7 @@ function Setup() {
       setQuoteLoading(false);
     };
 
-    const quoteReturned = (val: LegacyQuote) => {
+    const quoteReturned = (val: QuoteSwapResponse) => {
       if (!val || !fromAssetValue || !toAssetValue) {
         setQuoteLoading(false);
         setQuote(null);
@@ -128,14 +133,24 @@ function Setup() {
       }
       if (
         val &&
-        val.inputs &&
-        val.output &&
-        val.inputs.fromAmount === fromAmountValue &&
-        val.inputs.fromAsset.address === fromAssetValue.address &&
-        val.inputs.toAsset.address === toAssetValue.address
+        val.encodedData &&
+        val.maxReturn &&
+        val.maxReturn.totalFrom ===
+          BigNumber(fromAmountValue)
+            .multipliedBy(10 ** fromAssetValue.decimals)
+            .toFixed(0) &&
+        (val.maxReturn.from.toLowerCase() ===
+          fromAssetValue.address.toLowerCase() ||
+          (val.maxReturn.from ===
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" &&
+            fromAssetValue.address === NATIVE_TOKEN.address)) &&
+        (val.maxReturn.to.toLowerCase() ===
+          toAssetValue.address.toLowerCase() ||
+          (val.maxReturn.to === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" &&
+            toAssetValue.address === NATIVE_TOKEN.address))
       ) {
         setQuoteLoading(false);
-        if (BigNumber(val.output.finalValue ?? "0").eq(0)) {
+        if (BigNumber(val.maxReturn.totalTo).eq(0)) {
           setQuote(null);
           setToAmountValue("");
           setToAmountValueUsd("");
@@ -145,12 +160,17 @@ function Setup() {
           return;
         }
 
-        setToAmountValue(BigNumber(val.output.finalValue ?? "0").toFixed(8));
+        setToAmountValue(
+          BigNumber(val.maxReturn.totalTo)
+            .div(10 ** toAssetValue.decimals)
+            .toFixed(toAssetValue.decimals, BigNumber.ROUND_DOWN)
+        );
         const toAddressLookUp =
-          val.inputs.toAsset.address === NATIVE_TOKEN.address
+          val.maxReturn.to === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
             ? W_NATIVE_ADDRESS.toLowerCase()
-            : val.inputs.toAsset.address.toLowerCase();
-        const toUsdValue = BigNumber(val.output.finalValue ?? "0")
+            : val.maxReturn.to.toLowerCase();
+        const toUsdValue = BigNumber(val.maxReturn.totalTo)
+          .div(10 ** toAssetValue.decimals)
           .multipliedBy(tokenPrices?.get(toAddressLookUp) ?? 0)
           .toFixed(2);
         setToAmountValueUsd(toUsdValue);
@@ -426,10 +446,7 @@ function Setup() {
         content: {
           fromAsset: fromAssetValue,
           toAsset: toAssetValue,
-          fromAmount: fromAmountValue,
-          toAmount: toAmountValue,
-          quote: quote,
-          slippage: slippage,
+          quote,
         },
       });
     }
@@ -592,7 +609,12 @@ function Setup() {
         </div>
       );
     }
-
+    const totalFromInEth = fromAssetValue
+      ? BigNumber(quote.maxReturn.totalFrom).div(10 ** fromAssetValue.decimals)
+      : BigNumber(0);
+    const totalToInEth = toAssetValue
+      ? BigNumber(quote.maxReturn.totalTo).div(10 ** toAssetValue.decimals)
+      : BigNumber(0);
     return (
       <div className="mt-3 flex w-full flex-wrap items-center rounded-[10px] p-3">
         <Typography className="w-full border-b border-solid border-[rgba(126,153,176,0.2)] pb-[6px] text-sm font-bold text-cantoGreen">
@@ -602,9 +624,7 @@ function Setup() {
           <div className="flex flex-col items-center justify-center py-6 px-0">
             <Typography className="pb-[6px] text-sm font-bold">
               {formatCurrency(
-                BigNumber(quote.inputs.fromAmount)
-                  .div(quote.output.finalValue ?? "0")
-                  .toFixed(18)
+                BigNumber(totalFromInEth).div(totalToInEth).toFixed(18)
               )}
             </Typography>
             <Typography className="text-xs text-secondaryGray">{`${fromAssetValue?.symbol} per ${toAssetValue?.symbol}`}</Typography>
@@ -612,24 +632,12 @@ function Setup() {
           <div className="flex flex-col items-center justify-center py-6 px-0">
             <Typography className="pb-[6px] text-sm font-bold">
               {formatCurrency(
-                BigNumber(quote.output.finalValue ?? "0")
-                  .div(quote.inputs.fromAmount)
-                  .toFixed(18)
+                BigNumber(totalToInEth).div(totalFromInEth).toFixed(18)
               )}
             </Typography>
             <Typography className="text-xs text-secondaryGray">{`${toAssetValue?.symbol} per ${fromAssetValue?.symbol}`}</Typography>
           </div>
         </div>
-        {BigNumber(quote.priceImpact).gt(5) && (
-          <>
-            <Typography
-              className="w-full border-b border-solid border-[rgba(126,153,176,0.2)] pb-[6px] text-sm font-bold text-red-500"
-              align="center"
-            >
-              Price impact {formatCurrency(quote.priceImpact)}%
-            </Typography>
-          </>
-        )}
         {((usdDiff && Math.abs(parseFloat(usdDiff)) > 10) ||
           (parseFloat(fromAmountValueUsd) > 0 &&
             parseFloat(toAmountValueUsd) === 0)) && (
@@ -858,11 +866,28 @@ function Setup() {
             )}
           </Button>
         </div>
+        <div className="mt-2 text-end text-xs">
+          <span className="align-middle text-secondaryGray">Powered by </span>
+          <a
+            href="https://firebird.finance/"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="cursor-pointer grayscale transition-all hover:text-[#f66432] hover:grayscale-0"
+          >
+            <img
+              src="/images/logo-firebird.svg"
+              className="inline"
+              alt="firebird protocol logo"
+            />{" "}
+            <span className="align-middle">Firebird</span>
+          </a>
+        </div>
       </div>
       <RoutesDialog
         onClose={() => setRoutesOpen(false)}
         open={routesOpen}
-        paths={quote}
+        paths={quote?.maxReturn.paths}
+        tokens={quote?.maxReturn.tokens}
         fromAssetValue={fromAssetValue}
         fromAmountValue={fromAmountValue}
         toAssetValue={toAssetValue}
@@ -1171,6 +1196,7 @@ function RoutesDialog({
   onClose,
   open,
   paths,
+  tokens,
   fromAssetValue,
   toAssetValue,
   fromAmountValue,
@@ -1178,7 +1204,8 @@ function RoutesDialog({
 }: {
   onClose: () => void;
   open: boolean;
-  paths: LegacyQuote | null;
+  paths: Path[] | undefined;
+  tokens: FireBirdTokens | undefined;
   fromAssetValue: BaseAsset | null;
   toAssetValue: BaseAsset | null;
   fromAmountValue: string;
@@ -1214,28 +1241,6 @@ function RoutesDialog({
                 {formatCurrency(fromAmountValue)} {fromAssetValue.symbol}
               </span>
             </div>
-            {`->`}
-            {paths.output.routeAsset && (
-              <>
-                <div>
-                  <span className="mr-1 align-middle text-sm">
-                    {paths.output.routeAsset.symbol}
-                  </span>
-                  <img
-                    className="inline-block h-12 rounded-[30px] border border-[rgba(126,153,153,0.5)] bg-[#032725] p-[6px]"
-                    alt=""
-                    src={paths.output.routeAsset.logoURI || ""}
-                    height="40px"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).onerror = null;
-                      (e.target as HTMLImageElement).src =
-                        "/tokens/unknown-logo.png";
-                    }}
-                  />
-                </div>
-                {`->`}
-              </>
-            )}
             <div>
               <span className="mr-1 align-middle text-sm">
                 {formatCurrency(toAmountValue)} {toAssetValue.symbol}
@@ -1252,6 +1257,37 @@ function RoutesDialog({
                 }}
               />
             </div>
+          </div>
+          <div className="px-6">
+            {paths.map((path, idx) => (
+              <div
+                key={path.amountFrom + idx}
+                className="relative flex border-cantoGreen py-6 px-[5%] before:absolute before:left-0 before:top-0 before:h-12 before:w-full before:rounded-b-3xl before:rounded-br-3xl before:border-b before:border-dashed before:border-cantoGreen after:w-16 first:pt-7 last:before:border-l last:before:border-r [&:not(:last-child)]:border-x [&:not(:last-child)]:border-dashed"
+              >
+                <div className="relative flex flex-grow">
+                  <div className="flex flex-grow justify-between gap-4">
+                    <div>
+                      {BigNumber(path.amountFrom)
+                        .div(10 ** fromAssetValue.decimals)
+                        .div(fromAmountValue)
+                        .multipliedBy(100)
+                        .toFixed()}
+                      %
+                    </div>
+                    {path.swaps.map((swap, idx) => {
+                      if (idx === path.swaps.length - 1) return null;
+                      return (
+                        tokens && (
+                          <div key={swap.to + idx}>
+                            {tokens[swap.to].symbol}
+                          </div>
+                        )
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       ) : (

--- a/Frontend-v1-Original/pages/api/firebird-router.ts
+++ b/Frontend-v1-Original/pages/api/firebird-router.ts
@@ -1,3 +1,4 @@
+import { pulsechain } from "viem/chains";
 import BigNumber from "bignumber.js";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -28,7 +29,7 @@ export default async function handler(
 
   try {
     const quote = await fetch(
-      `https://router.firebird.finance/aggregator/v1/route?chainId=7700&from=${fromAsset.address}&to=${toAsset.address}&amount=${sendFromAmount}&slippage=${slippage}&receiver=${address}&source=velocimeter&dexes=velocimeterv1,velocimeterv2`,
+      `https://router.firebird.finance/aggregator/v1/route?chainId=${pulsechain.id}&from=${fromAsset.address}&to=${toAsset.address}&amount=${sendFromAmount}&slippage=${slippage}&receiver=${address}&source=velocimeter&dexes=velocimeter`,
       {
         method: "GET",
         headers: {

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -14,7 +14,6 @@ import {
   type WriteContractReturnType,
   isAddress,
   BaseError,
-  Address,
 } from "viem";
 import { pulsechain } from "viem/chains";
 import { getAccount, getWalletClient } from "@wagmi/core";
@@ -47,13 +46,13 @@ import {
   VestNFT,
   GovToken,
   Votes,
+  QuoteSwapResponse,
   Bribe,
   VeDistReward,
   ITransaction,
   Gauge,
   hasGauge,
   TransactionStatus,
-  LegacyQuote,
 } from "./types/types";
 
 import stores from ".";
@@ -1364,7 +1363,7 @@ class Store {
       this.setStore({ govToken: this._getGovTokenBase() });
       this.setStore({ veToken: this._getVeTokenBase() });
       this.setStore({ baseAssets: await this._getBaseAssets() });
-      this.setStore({ routeAssets: await this._getRouteAssets() }); // We need it because we use firebird router
+      // this.setStore({ routeAssets: await this._getRouteAssets() }); // We dont need it because we use firebird router
       this.setStore({ pairs: await this._getPairs() });
       this.setStore({ swapAssets: this._getSwapAssets() });
       this.setStore({ updateDate: await stores.helper.getActivePeriod() });
@@ -3637,36 +3636,6 @@ class Store {
     }
   };
 
-  // quoteSwap = async (payload: {
-  //   type: string;
-  //   content: {
-  //     fromAsset: BaseAsset;
-  //     toAsset: BaseAsset;
-  //     fromAmount: string;
-  //     slippage: number;
-  //   };
-  // }) => {
-  //   const address = getAccount().address;
-  //   if (!address) throw new Error("no address");
-  //   try {
-  //     const res = await fetch("/api/firebird-router", {
-  //       method: "POST",
-  //       body: JSON.stringify({
-  //         payload,
-  //         address,
-  //       }),
-  //     });
-  //     const resJson = (await res.json()) as QuoteSwapResponse;
-
-  //     const returnValue = resJson;
-
-  //     this.emitter.emit(ACTIONS.QUOTE_SWAP_RETURNED, returnValue);
-  //   } catch (ex) {
-  //     console.error(ex);
-  //     this.emitter.emit(ACTIONS.QUOTE_SWAP_RETURNED, null);
-  //     this.emitter.emit(ACTIONS.ERROR, ex);
-  //   }
-  // };
   quoteSwap = async (payload: {
     type: string;
     content: {
@@ -3676,275 +3645,19 @@ class Store {
       slippage: number;
     };
   }) => {
+    const address = getAccount().address;
+    if (!address) throw new Error("no address");
     try {
-      const walletClient = await getWalletClient({ chainId: pulsechain.id });
-      if (!walletClient) {
-        console.warn("wallet");
-        return null;
-      }
-
-      // route assets are USDC, WCANTO and FLOW
-      const routeAssets = this.getStore("routeAssets");
-      const { fromAsset, toAsset, fromAmount } = payload.content;
-
-      const routerContract = {
-        abi: CONTRACTS.ROUTER_ABI,
-        address: CONTRACTS.ROUTER_ADDRESS,
-      } as const;
-
-      const sendFromAmount = BigNumber(fromAmount)
-        .times(10 ** fromAsset.decimals)
-        .toFixed();
-
-      if (
-        !fromAsset ||
-        !toAsset ||
-        !fromAmount ||
-        !fromAsset.address ||
-        !toAsset.address ||
-        fromAmount === ""
-      ) {
-        return null;
-      }
-
-      let addy0 = fromAsset.address;
-      let addy1 = toAsset.address;
-
-      if (fromAsset.address === NATIVE_TOKEN.symbol) {
-        // @ts-expect-error W_NATIVE_ADDRESS is of type `0x${string}`
-        addy0 = W_NATIVE_ADDRESS;
-      }
-      if (toAsset.address === NATIVE_TOKEN.symbol) {
-        // @ts-expect-error W_NATIVE_ADDRESS is of type `0x${string}`
-        addy1 = W_NATIVE_ADDRESS;
-      }
-
-      const includesRouteAddress = routeAssets.filter((asset) => {
-        return (
-          asset.address.toLowerCase() == addy0.toLowerCase() ||
-          asset.address.toLowerCase() == addy1.toLowerCase()
-        );
+      const res = await fetch("/api/firebird-router", {
+        method: "POST",
+        body: JSON.stringify({
+          payload,
+          address,
+        }),
       });
+      const resJson = (await res.json()) as QuoteSwapResponse;
 
-      let amountOuts: {
-        routes: { from: Address; to: Address; stable: boolean }[];
-        routeAsset: RouteAsset | null;
-        receiveAmounts?: string[];
-        finalValue?: string;
-      }[] = [];
-      // In case router multicall will break make sure you have stable pair with some $$ in it
-      if (includesRouteAddress.length === 0) {
-        amountOuts = routeAssets
-          .map((routeAsset) => {
-            return [
-              {
-                routes: [
-                  {
-                    from: addy0,
-                    to: routeAsset.address,
-                    stable: true,
-                  },
-                  {
-                    from: routeAsset.address,
-                    to: addy1,
-                    stable: true,
-                  },
-                ],
-                routeAsset: routeAsset,
-              },
-              {
-                routes: [
-                  {
-                    from: addy0,
-                    to: routeAsset.address,
-                    stable: false,
-                  },
-                  {
-                    from: routeAsset.address,
-                    to: addy1,
-                    stable: false,
-                  },
-                ],
-                routeAsset: routeAsset,
-              },
-              {
-                routes: [
-                  {
-                    from: addy0,
-                    to: routeAsset.address,
-                    stable: true,
-                  },
-                  {
-                    from: routeAsset.address,
-                    to: addy1,
-                    stable: false,
-                  },
-                ],
-                routeAsset: routeAsset,
-              },
-              {
-                routes: [
-                  {
-                    from: addy0,
-                    to: routeAsset.address,
-                    stable: false,
-                  },
-                  {
-                    from: routeAsset.address,
-                    to: addy1,
-                    stable: true,
-                  },
-                ],
-                routeAsset: routeAsset,
-              },
-            ];
-          })
-          .flat();
-      }
-
-      amountOuts.push({
-        routes: [
-          {
-            from: addy0,
-            to: addy1,
-            stable: true,
-          },
-        ],
-        routeAsset: null,
-      });
-
-      amountOuts.push({
-        routes: [
-          {
-            from: addy0,
-            to: addy1,
-            stable: false,
-          },
-        ],
-        routeAsset: null,
-      });
-
-      const amountsOutCalls = amountOuts.map((route) => {
-        return {
-          ...routerContract,
-          functionName: "getAmountsOut",
-          args: [BigInt(sendFromAmount), route.routes],
-        } as const;
-      });
-
-      const amountsOutResult = await viemClient.multicall({
-        allowFailure: true,
-        contracts: amountsOutCalls,
-      });
-
-      const results = amountsOutResult
-        .filter((result) => result.status === "success")
-        .map((result) => result.result as bigint[]);
-
-      let receiveAmounts: string[][] = [];
-
-      for (const returnValue of results) {
-        if (!returnValue) {
-          receiveAmounts.push([sendFromAmount, "0", "0"]);
-          continue;
-        }
-        const arr = returnValue.map((bigint) => {
-          return bigint.toString();
-        });
-        // const arr = returnValue.map((bigint) => {
-        //   return web3.utils.hexToNumberString(bignumber.hex);
-        // });
-        receiveAmounts.push(arr);
-      }
-
-      for (let i = 0; i < receiveAmounts.length; i++) {
-        amountOuts[i].receiveAmounts = receiveAmounts[i];
-        amountOuts[i].finalValue = BigNumber(
-          receiveAmounts[i][receiveAmounts[i].length - 1]
-        )
-          .div(10 ** toAsset.decimals)
-          .toFixed(toAsset.decimals);
-      }
-
-      // const bestAmountOut = amountOuts
-      //   .filter((ret) => {
-      //     return ret != null;
-      //   })
-      //   .reduce((best, current) => {
-      //     return BigNumber(best.finalValue).gt(current.finalValue)
-      //       ? best
-      //       : current;
-      //   }, 0);
-      const bestAmountOut = amountOuts.reduce((prev, current) => {
-        return BigNumber(prev.finalValue ?? "0").gt(current.finalValue ?? "0")
-          ? prev
-          : current;
-      });
-
-      if (!bestAmountOut) {
-        this.emitter.emit(
-          ACTIONS.ERROR,
-          "No valid route found to complete swap"
-        );
-        return null;
-      }
-
-      let totalRatio = "1";
-
-      for (let i = 0; i < bestAmountOut.routes.length; i++) {
-        if (bestAmountOut.routes[i].stable == true) {
-        } else {
-          // const reserves = await routerContract.methods
-          //   .getReserves(
-          //     bestAmountOut.routes[i].from,
-          //     bestAmountOut.routes[i].to,
-          //     bestAmountOut.routes[i].stable
-          //   )
-          //   .call();
-          const reserves = await viemClient.readContract({
-            ...routerContract,
-            functionName: "getReserves",
-            args: [
-              bestAmountOut.routes[i].from,
-              bestAmountOut.routes[i].to,
-              bestAmountOut.routes[i].stable,
-            ],
-          });
-          let amountIn = "0";
-          let amountOut = "0";
-          if (i == 0) {
-            amountIn = sendFromAmount;
-            amountOut = bestAmountOut.receiveAmounts
-              ? bestAmountOut.receiveAmounts[i + 1]
-              : "0";
-          } else {
-            amountIn = bestAmountOut.receiveAmounts
-              ? bestAmountOut.receiveAmounts[i]
-              : "0";
-            amountOut = bestAmountOut.receiveAmounts
-              ? bestAmountOut.receiveAmounts[i + 1]
-              : "0";
-          }
-
-          const amIn = BigNumber(amountIn).div(reserves[0].toString());
-          const amOut = BigNumber(amountOut).div(reserves[1].toString());
-          const ratio = BigNumber(amOut).div(amIn);
-
-          totalRatio = BigNumber(totalRatio).times(ratio).toFixed(18);
-        }
-      }
-
-      const priceImpact = BigNumber(1).minus(totalRatio).times(100).toFixed(18);
-
-      const returnValue = {
-        inputs: {
-          fromAmount: fromAmount,
-          fromAsset: fromAsset,
-          toAsset: toAsset,
-        },
-        output: bestAmountOut,
-        priceImpact: priceImpact,
-      };
+      const returnValue = resJson;
 
       this.emitter.emit(ACTIONS.QUOTE_SWAP_RETURNED, returnValue);
     } catch (ex) {
@@ -3957,11 +3670,9 @@ class Store {
   swap = async (payload: {
     type: string;
     content: {
-      quote: LegacyQuote;
+      quote: QuoteSwapResponse;
       fromAsset: BaseAsset;
       toAsset: BaseAsset;
-      fromAmount: string;
-      slippage: string;
     };
   }) => {
     try {
@@ -3973,8 +3684,11 @@ class Store {
 
       const [account] = await walletClient.getAddresses();
 
-      const { fromAsset, toAsset, fromAmount, quote, slippage } =
-        payload.content;
+      const { quote, fromAsset, toAsset } = payload.content;
+
+      const fromAmount = BigNumber(quote.maxReturn.totalFrom)
+        .div(10 ** fromAsset.decimals)
+        .toFixed(fromAsset.decimals);
 
       // ADD TRNASCTIONS TO TRANSACTION QUEUE DISPLAY
       let allowanceTXID = this.getTXUUID();
@@ -4004,7 +3718,11 @@ class Store {
 
       // CHECK ALLOWANCES AND SET TX DISPLAY
       if (fromAsset.address !== NATIVE_TOKEN.symbol) {
-        allowance = await this._getSwapAllowance(fromAsset, account);
+        allowance = await this._getFirebirdSwapAllowance(
+          fromAsset,
+          account,
+          quote
+        );
         if (!allowance) throw new Error("Couldn't fetch allowance");
         if (BigNumber(allowance).lt(fromAmount)) {
           this.emitter.emit(ACTIONS.TX_STATUS, {
@@ -4034,81 +3752,81 @@ class Store {
           walletClient,
           allowanceTXID,
           fromAsset.address,
-          CONTRACTS.ROUTER_ADDRESS
+          quote.encodedData.router
         );
       }
 
       // SUBMIT SWAP TRANSACTION
-      const sendSlippage = BigNumber(100).minus(slippage).div(100);
-      const sendFromAmount = BigNumber(fromAmount)
-        .times(10 ** fromAsset.decimals)
-        .toFixed(0);
-      const sendMinAmountOut = BigNumber(quote.output.finalValue ?? "0")
-        .times(10 ** toAsset.decimals)
-        .times(sendSlippage)
-        .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
-
-      if (fromAsset.address === NATIVE_TOKEN.address) {
-        const writeSwapFromEth = async () => {
-          const { request } = await viemClient.simulateContract({
+      if (
+        quote.maxReturn.from === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      ) {
+        try {
+          this.emitter.emit(ACTIONS.TX_PENDING, { uuid: swapTXID });
+          const txHash = await walletClient.sendTransaction({
             account,
-            address: CONTRACTS.ROUTER_ADDRESS,
-            abi: CONTRACTS.ROUTER_ABI,
-            functionName: "swapExactETHForTokens",
-            args: [
-              BigInt(sendMinAmountOut),
-              quote.output.routes,
-              account,
-              BigInt(deadline),
-            ],
-            value: BigInt(sendFromAmount),
+            to: quote.encodedData.router,
+            value: BigInt(quote.maxReturn.totalFrom),
+            data: quote.encodedData.data,
+            gasPrice: BigInt(quote.maxReturn.gasPrice),
+            chain: pulsechain,
           });
-          const txHash = await walletClient.writeContract(request);
-          return txHash;
-        };
-
-        await this._writeContractWrapper(swapTXID, writeSwapFromEth);
-      } else if (toAsset.address === NATIVE_TOKEN.address) {
-        const writeSwapForEth = async () => {
-          const { request } = await viemClient.simulateContract({
-            account,
-            address: CONTRACTS.ROUTER_ADDRESS,
-            abi: CONTRACTS.ROUTER_ABI,
-            functionName: "swapExactTokensForETH",
-            args: [
-              BigInt(sendFromAmount),
-              BigInt(sendMinAmountOut),
-              quote.output.routes,
-              account,
-              BigInt(deadline),
-            ],
+          const receipt = await viemClient.waitForTransactionReceipt({
+            hash: txHash,
           });
-          const txHash = await walletClient.writeContract(request);
-          return txHash;
-        };
-
-        await this._writeContractWrapper(swapTXID, writeSwapForEth);
+          if (receipt.status === "success") {
+            this.emitter.emit(ACTIONS.TX_CONFIRMED, {
+              uuid: swapTXID,
+              txHash: receipt.transactionHash,
+            });
+          }
+        } catch (error) {
+          if (!(error as Error).toString().includes("-32601")) {
+            if ((error as Error).message) {
+              this.emitter.emit(ACTIONS.TX_REJECTED, {
+                uuid: swapTXID,
+                error: this._mapError((error as Error).message),
+              });
+            }
+            this.emitter.emit(ACTIONS.TX_REJECTED, {
+              uuid: swapTXID,
+              error: error,
+            });
+          }
+        }
       } else {
-        const writeSwap = async () => {
-          const { request } = await viemClient.simulateContract({
+        try {
+          this.emitter.emit(ACTIONS.TX_PENDING, { uuid: swapTXID });
+          const txHash = await walletClient.sendTransaction({
             account,
-            address: CONTRACTS.ROUTER_ADDRESS,
-            abi: CONTRACTS.ROUTER_ABI,
-            functionName: "swapExactTokensForTokens",
-            args: [
-              BigInt(sendFromAmount),
-              BigInt(sendMinAmountOut),
-              quote.output.routes,
-              account,
-              BigInt(deadline),
-            ],
+            to: quote.encodedData.router,
+            value: undefined,
+            data: quote.encodedData.data,
+            gasPrice: BigInt(quote.maxReturn.gasPrice),
+            chain: pulsechain,
           });
-          const txHash = await walletClient.writeContract(request);
-          return txHash;
-        };
-
-        await this._writeContractWrapper(swapTXID, writeSwap);
+          const receipt = await viemClient.waitForTransactionReceipt({
+            hash: txHash,
+          });
+          if (receipt.status === "success") {
+            this.emitter.emit(ACTIONS.TX_CONFIRMED, {
+              uuid: swapTXID,
+              txHash: receipt.transactionHash,
+            });
+          }
+        } catch (error) {
+          if (!(error as Error).toString().includes("-32601")) {
+            if ((error as Error).message) {
+              this.emitter.emit(ACTIONS.TX_REJECTED, {
+                uuid: swapTXID,
+                error: this._mapError((error as Error).message),
+              });
+            }
+            this.emitter.emit(ACTIONS.TX_REJECTED, {
+              uuid: swapTXID,
+              error: error,
+            });
+          }
+        }
       }
 
       this._getSpecificAssetInfo(account, fromAsset.address);
@@ -4121,178 +3839,6 @@ class Store {
       this.emitter.emit(ACTIONS.ERROR, ex);
     }
   };
-  // swap = async (payload: {
-  //   type: string;
-  //   content: {
-  //     quote: QuoteSwapResponse;
-  //     fromAsset: BaseAsset;
-  //     toAsset: BaseAsset;
-  //   };
-  // }) => {
-  //   try {
-  //     const walletClient = await getWalletClient({ chainId: pulsechain.id });
-  //     if (!walletClient) {
-  //       console.warn("wallet");
-  //       return null;
-  //     }
-
-  //     const [account] = await walletClient.getAddresses();
-
-  //     const { quote, fromAsset, toAsset } = payload.content;
-
-  //     const fromAmount = BigNumber(quote.maxReturn.totalFrom)
-  //       .div(10 ** fromAsset.decimals)
-  //       .toFixed(fromAsset.decimals);
-
-  //     // ADD TRNASCTIONS TO TRANSACTION QUEUE DISPLAY
-  //     let allowanceTXID = this.getTXUUID();
-  //     let swapTXID = this.getTXUUID();
-
-  //     this.emitter.emit(ACTIONS.TX_ADDED, {
-  //       title: `Swap ${fromAsset.symbol} for ${toAsset.symbol}`,
-  //       type: "Swap",
-  //       verb: "Swap Successful",
-  //       transactions: [
-  //         {
-  //           uuid: allowanceTXID,
-  //           description: `Checking your ${fromAsset.symbol} allowance`,
-  //           status: "WAITING",
-  //         },
-  //         {
-  //           uuid: swapTXID,
-  //           description: `Swap ${formatCurrency(fromAmount)} ${
-  //             fromAsset.symbol
-  //           } for ${toAsset.symbol}`,
-  //           status: "WAITING",
-  //         },
-  //       ],
-  //     });
-
-  //     let allowance: string | null = "0";
-
-  //     // CHECK ALLOWANCES AND SET TX DISPLAY
-  //     if (fromAsset.address !== NATIVE_TOKEN.symbol) {
-  //       allowance = await this._getFirebirdSwapAllowance(
-  //         fromAsset,
-  //         account,
-  //         quote
-  //       );
-  //       if (!allowance) throw new Error("Couldn't fetch allowance");
-  //       if (BigNumber(allowance).lt(fromAmount)) {
-  //         this.emitter.emit(ACTIONS.TX_STATUS, {
-  //           uuid: allowanceTXID,
-  //           description: `Allow the router to spend your ${fromAsset.symbol}`,
-  //         });
-  //       } else {
-  //         this.emitter.emit(ACTIONS.TX_STATUS, {
-  //           uuid: allowanceTXID,
-  //           description: `Allowance on ${fromAsset.symbol} sufficient`,
-  //           status: "DONE",
-  //         });
-  //       }
-  //     } else {
-  //       allowance = MAX_UINT256;
-  //       this.emitter.emit(ACTIONS.TX_STATUS, {
-  //         uuid: allowanceTXID,
-  //         description: `Allowance on ${fromAsset.symbol} sufficient`,
-  //         status: "DONE",
-  //       });
-  //     }
-
-  //     if (!allowance) throw new Error("Couldn't fetch allowance");
-  //     // SUBMIT REQUIRED ALLOWANCE TRANSACTIONS
-  //     if (BigNumber(allowance).lt(fromAmount)) {
-  //       await this.writeApprove(
-  //         walletClient,
-  //         allowanceTXID,
-  //         fromAsset.address,
-  //         quote.encodedData.router
-  //       );
-  //     }
-
-  //     // SUBMIT SWAP TRANSACTION
-  //     if (
-  //       quote.maxReturn.from === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-  //     ) {
-  //       try {
-  //         this.emitter.emit(ACTIONS.TX_PENDING, { uuid: swapTXID });
-  //         const txHash = await walletClient.sendTransaction({
-  //           account,
-  //           to: quote.encodedData.router,
-  //           value: BigInt(quote.maxReturn.totalFrom),
-  //           data: quote.encodedData.data,
-  //           gasPrice: BigInt(quote.maxReturn.gasPrice),
-  //           chain: pulsechain,
-  //         });
-  //         const receipt = await viemClient.waitForTransactionReceipt({
-  //           hash: txHash,
-  //         });
-  //         if (receipt.status === "success") {
-  //           this.emitter.emit(ACTIONS.TX_CONFIRMED, {
-  //             uuid: swapTXID,
-  //             txHash: receipt.transactionHash,
-  //           });
-  //         }
-  //       } catch (error) {
-  //         if (!(error as Error).toString().includes("-32601")) {
-  //           if ((error as Error).message) {
-  //             this.emitter.emit(ACTIONS.TX_REJECTED, {
-  //               uuid: swapTXID,
-  //               error: this._mapError((error as Error).message),
-  //             });
-  //           }
-  //           this.emitter.emit(ACTIONS.TX_REJECTED, {
-  //             uuid: swapTXID,
-  //             error: error,
-  //           });
-  //         }
-  //       }
-  //     } else {
-  //       try {
-  //         this.emitter.emit(ACTIONS.TX_PENDING, { uuid: swapTXID });
-  //         const txHash = await walletClient.sendTransaction({
-  //           account,
-  //           to: quote.encodedData.router,
-  //           value: undefined,
-  //           data: quote.encodedData.data,
-  //           gasPrice: BigInt(quote.maxReturn.gasPrice),
-  //           chain: pulsechain,
-  //         });
-  //         const receipt = await viemClient.waitForTransactionReceipt({
-  //           hash: txHash,
-  //         });
-  //         if (receipt.status === "success") {
-  //           this.emitter.emit(ACTIONS.TX_CONFIRMED, {
-  //             uuid: swapTXID,
-  //             txHash: receipt.transactionHash,
-  //           });
-  //         }
-  //       } catch (error) {
-  //         if (!(error as Error).toString().includes("-32601")) {
-  //           if ((error as Error).message) {
-  //             this.emitter.emit(ACTIONS.TX_REJECTED, {
-  //               uuid: swapTXID,
-  //               error: this._mapError((error as Error).message),
-  //             });
-  //           }
-  //           this.emitter.emit(ACTIONS.TX_REJECTED, {
-  //             uuid: swapTXID,
-  //             error: error,
-  //           });
-  //         }
-  //       }
-  //     }
-
-  //     this._getSpecificAssetInfo(account, fromAsset.address);
-  //     this._getSpecificAssetInfo(account, toAsset.address);
-  //     this._getPairInfo(account);
-
-  //     this.emitter.emit(ACTIONS.SWAP_RETURNED);
-  //   } catch (ex) {
-  //     console.error(ex);
-  //     this.emitter.emit(ACTIONS.ERROR, ex);
-  //   }
-  // };
 
   wrapOrUnwrap = async (payload: {
     type: string;
@@ -4400,33 +3946,17 @@ class Store {
     }
   };
 
-  // _getFirebirdSwapAllowance = async (
-  //   token: BaseAsset,
-  //   address: `0x${string}`,
-  //   quote: QuoteSwapResponse
-  // ) => {
-  //   try {
-  //     const allowance = await viemClient.readContract({
-  //       address: token.address,
-  //       abi: CONTRACTS.ERC20_ABI,
-  //       functionName: "allowance",
-  //       args: [address, quote.encodedData.router],
-  //     });
-
-  //     return formatUnits(allowance, token.decimals);
-  //   } catch (ex) {
-  //     console.error(ex);
-  //     return null;
-  //   }
-  // };
-
-  _getSwapAllowance = async (token: BaseAsset, account: `0x${string}`) => {
+  _getFirebirdSwapAllowance = async (
+    token: BaseAsset,
+    address: `0x${string}`,
+    quote: QuoteSwapResponse
+  ) => {
     try {
       const allowance = await viemClient.readContract({
         address: token.address,
         abi: CONTRACTS.ERC20_ABI,
         functionName: "allowance",
-        args: [account, CONTRACTS.ROUTER_ADDRESS],
+        args: [address, quote.encodedData.router],
       });
 
       return formatUnits(allowance, token.decimals);
@@ -4435,6 +3965,25 @@ class Store {
       return null;
     }
   };
+
+  // _getSwapAllowance = async (
+  //   token: BaseAsset,
+  //   account: { address: string }
+  // ) => {
+  //   try {
+  //     const allowance = await viemClient.readContract({
+  //       address: token.address ,
+  //       abi: CONTRACTS.ERC20_ABI,
+  //       functionName: "allowance",
+  //       args: [account , CONTRACTS.ROUTER_ADDRESS],
+  //     });
+
+  //     return formatUnits(allowance, token.decimals);
+  //   } catch (ex) {
+  //     console.error(ex);
+  //     return null;
+  //   }
+  // };
 
   getVestNFTs = async () => {
     try {

--- a/Frontend-v1-Original/stores/types/types.ts
+++ b/Frontend-v1-Original/stores/types/types.ts
@@ -285,25 +285,6 @@ interface FireBirdTokens {
   };
 }
 
-interface LegacyQuote {
-  inputs: {
-    fromAmount: string;
-    fromAsset: BaseAsset;
-    toAsset: BaseAsset;
-  };
-  output: {
-    routes: {
-      from: `0x${string}`;
-      to: `0x${string}`;
-      stable: boolean;
-    }[];
-    routeAsset: RouteAsset | null;
-    receiveAmounts?: string[] | undefined;
-    finalValue?: string | undefined;
-  };
-  priceImpact: string;
-}
-
 export type {
   BaseAsset,
   Pair,
@@ -323,7 +304,6 @@ export type {
   EthWindow,
   QuoteSwapPayload,
   QuoteSwapResponse,
-  LegacyQuote,
   Path,
   Swap,
   FireBirdTokens,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR replaces the legacy quote system with the Firebird Router for improved swapping. 

### Detailed summary
- Replaces `LegacyQuote` with `QuoteSwapResponse`
- Replaces `quoteReturned` function with `quoteSwap`
- Removes `routeAssets` from store
- Uses Firebird Router in `firebird-router.ts` instead of Velocimeter
- Updates `setup.tsx` to use `QuoteSwapResponse` instead of `LegacyQuote`
- Adds Firebird logo and attribution to `setup.tsx`
- Removes commented out code for `quoteSwap` function using Velocimeter

> The following files were skipped due to too many changes: `Frontend-v1-Original/stores/stableSwapStore.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->