### PR TITLE
disable lock button when max locked

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -25,7 +25,7 @@ import { GovToken, VeToken, VestNFT } from "../../stores/types/types";
 import VestingInfo from "./vestingInfo";
 import classes from "./ssVest.module.css";
 
-import { lockOptions } from "./lockDuration";
+import { type LockOption, lockOptions } from "./lockDuration";
 
 export default function Lock({
   govToken,
@@ -333,7 +333,7 @@ export default function Lock({
                   <FormControlLabel
                     key={key}
                     className={classes.vestPeriodLabel}
-                    value={lockOptions[key]}
+                    value={lockOptions[key as LockOption]}
                     control={<Radio color="primary" />}
                     label={key}
                     labelPlacement="end"


### PR DESCRIPTION
Cherry picking https://github.com/Velocimeter/frontend/pull/115/commits/7a59fe7b8bd5b5f566493fa31d29b3f573d94763

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `LockOption` type to `lockDuration.tsx` and uses it in `lock.tsx`. It also adds a new `roundDownToWeekBoundary` function to `lockDuration.tsx` and uses it to prevent locking beyond 4 years.

### Detailed summary
- Adds a new `LockOption` type to `lockDuration.tsx`
- Uses `LockOption` type in `lock.tsx`
- Adds `roundDownToWeekBoundary` function to `lockDuration.tsx`
- Uses `roundDownToWeekBoundary` to prevent locking beyond 4 years in `lock.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->