### PR TITLE
fix scan path

### DIFF
--- a/Frontend-v1-Original/stores/constants/constants.ts
+++ b/Frontend-v1-Original/stores/constants/constants.ts
@@ -6,7 +6,7 @@ import * as actions from "./actions";
 
 const config = {
   [pulsechain.id]: {
-    scan: "https://scan.pulsechain.com",
+    scan: "https://scan.pulsechain.com/",
     contracts: contracts,
     nativeETH: {
       address: contracts.ETH_ADDRESS,


### PR DESCRIPTION
The trailing slash is needed. Currently I'm getting urls like `https://scan.pulsechain.comtx/`

Canto version:

![20230609S4NMfFUU@2x](https://github.com/Velocimeter/frontend/assets/126733611/92c66698-e820-45a0-8dfc-4d9d54349ed7)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `scan` URL for the `pulsechain.id` configuration in `constants.ts`.

### Detailed summary
- Updated `scan` URL for `pulsechain.id` configuration in `constants.ts`.
- Trailing slash added to `scan` URL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->