### PR TITLE
apply dayjs changes from pulse branch

### DIFF
--- a/Frontend-v1-Original/components/ssVest/existingLock.tsx
+++ b/Frontend-v1-Original/components/ssVest/existingLock.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 import { Paper, Typography, IconButton } from "@mui/material";
-import moment from "moment";
+import dayjs from "dayjs";
 import BigNumber from "bignumber.js";
 import { ArrowBack } from "@mui/icons-material";
 
@@ -57,8 +57,8 @@ export default function ExistingLock({
       influence: nft.influence,
     };
 
-    const now = moment();
-    const expiry = moment.unix(+tmpNFT.lockEnds);
+    const now = dayjs();
+    const expiry = dayjs.unix(+tmpNFT.lockEnds);
     const dayToExpire = expiry.diff(now, "days");
 
     tmpNFT.lockAmount = BigNumber(nft.lockAmount).plus(amount).toFixed(18);
@@ -82,8 +82,8 @@ export default function ExistingLock({
       influence: nft.influence,
     };
 
-    const now = moment();
-    const expiry = moment(val);
+    const now = dayjs();
+    const expiry = dayjs(val);
     const dayToExpire = expiry.diff(now, "days");
 
     tmpNFT.lockEnds = expiry.unix().toString();

--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { useRouter } from "next/router";
 import BigNumber from "bignumber.js";
-import moment from "moment";
+import dayjs from "dayjs";
 import { ArrowBack } from "@mui/icons-material";
 
 import { formatCurrency } from "../../utils/utils";
@@ -43,7 +43,7 @@ export default function Lock({
   const [amountError, setAmountError] = useState<string | false>(false);
   const [selectedValue, setSelectedValue] = useState<string | null>("8"); // select 1 week by default
   const [selectedDate, setSelectedDate] = useState(
-    moment().add(7, "days").format("YYYY-MM-DD")
+    dayjs().add(7, "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
 
@@ -82,7 +82,7 @@ export default function Lock({
     setSelectedValue(event.target.value);
 
     let days = +event.target.value ?? 0;
-    const newDate = moment().add(days, "days").format("YYYY-MM-DD");
+    const newDate = dayjs().add(days, "days").format("YYYY-MM-DD");
 
     setSelectedDate(newDate);
   };
@@ -115,8 +115,8 @@ export default function Lock({
     if (!error) {
       setLockLoading(true);
 
-      const now = moment();
-      const expiry = moment(selectedDate).add(1, "days");
+      const now = dayjs();
+      const expiry = dayjs(selectedDate).add(1, "days");
       const secondsToExpire = expiry.diff(now, "seconds");
 
       stores.dispatcher.dispatch({
@@ -172,8 +172,8 @@ export default function Lock({
               onChange={amountChanged}
               disabled={lockLoading}
               inputProps={{
-                min: moment().add(7, "days").format("YYYY-MM-DD"),
-                max: moment().add(1460, "days").format("YYYY-MM-DD"),
+                min: dayjs().add(7, "days").format("YYYY-MM-DD"),
+                max: dayjs().add(1460, "days").format("YYYY-MM-DD"),
               }}
               InputProps={{
                 className: classes.largeInput,
@@ -271,8 +271,8 @@ export default function Lock({
   };
 
   const renderVestInformation = () => {
-    const now = moment();
-    const expiry = moment(selectedDate);
+    const now = dayjs();
+    const expiry = dayjs(selectedDate);
     const dayToExpire = expiry.diff(now, "days");
 
     const tmpNFT: VestNFT = {

--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -9,7 +9,7 @@ import {
   FormControlLabel,
 } from "@mui/material";
 import { useRouter } from "next/router";
-import moment from "moment";
+import dayjs from "dayjs";
 import BigNumber from "bignumber.js";
 
 import stores from "../../stores";
@@ -39,7 +39,7 @@ export const lockOptions: Record<LockOption, number> = {
  * @param date
  * @returns timestamp of the start of the epoch, i.e., thursday 00:00 UTC
  */
-function roundDownToWeekBoundary(date: moment.Moment) {
+function roundDownToWeekBoundary(date: dayjs.Dayjs) {
   const WEEK = 7 * 24 * 60 * 60 * 1000;
   // convert date to timestamp
   const timestamp = date.valueOf();
@@ -57,7 +57,7 @@ export default function LockDuration({
   const [lockLoading, setLockLoading] = useState(false);
 
   const [selectedDate, setSelectedDate] = useState(
-    moment().add(8, "days").format("YYYY-MM-DD")
+    dayjs().add(8, "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
@@ -86,7 +86,7 @@ export default function LockDuration({
 
   useEffect(() => {
     if (nft && nft.lockEnds) {
-      setSelectedDate(moment.unix(+nft.lockEnds).format("YYYY-MM-DD"));
+      setSelectedDate(dayjs.unix(+nft.lockEnds).format("YYYY-MM-DD"));
       setSelectedValue(null);
     }
   }, [nft]);
@@ -102,7 +102,7 @@ export default function LockDuration({
     setSelectedValue(event.target.value);
 
     let days = +event.target.value ?? 0;
-    const newDate = moment().add(days, "days").format("YYYY-MM-DD");
+    const newDate = dayjs().add(days, "days").format("YYYY-MM-DD");
 
     setSelectedDate(newDate);
     updateLockDuration(newDate);
@@ -111,8 +111,8 @@ export default function LockDuration({
   const onLock = () => {
     setLockLoading(true);
 
-    const now = moment();
-    const expiry = moment(selectedDate).add(1, "days");
+    const now = dayjs();
+    const expiry = dayjs(selectedDate).add(1, "days");
     const secondsToExpire = expiry.diff(now, "seconds");
 
     stores.dispatcher.dispatch({
@@ -125,9 +125,9 @@ export default function LockDuration({
     inputEl.current?.focus();
   };
 
-  let min = moment().add(7, "days").format("YYYY-MM-DD");
+  let min = dayjs().add(7, "days").format("YYYY-MM-DD");
   if (BigNumber(nft?.lockEnds).gt(0)) {
-    min = moment.unix(+nft?.lockEnds).format("YYYY-MM-DD");
+    min = dayjs.unix(+nft?.lockEnds).format("YYYY-MM-DD");
   }
 
   const renderMassiveInput = (
@@ -168,7 +168,7 @@ export default function LockDuration({
               disabled={lockLoading}
               inputProps={{
                 min: min,
-                max: moment().add(1460, "days").format("YYYY-MM-DD"),
+                max: dayjs().add(1460, "days").format("YYYY-MM-DD"),
               }}
               InputProps={{
                 className: classes.largeInput,
@@ -180,7 +180,7 @@ export default function LockDuration({
     );
   };
 
-  const max = moment().add(lockOptions["4 years"], "days");
+  const max = dayjs().add(lockOptions["4 years"], "days");
   const roundedDownMax = roundDownToWeekBoundary(max);
   const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
   return (

--- a/Frontend-v1-Original/components/ssVest/ssVest.tsx
+++ b/Frontend-v1-Original/components/ssVest/ssVest.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import BigNumber from "bignumber.js";
-import moment from "moment";
+import dayjs from "dayjs";
 
 import stores from "../../stores";
 import { ACTIONS } from "../../stores/constants/constants";
@@ -53,13 +53,13 @@ export default function Vest() {
       )}
       {router.query.id !== "create" &&
         nft &&
-        BigNumber(nft.lockEnds).gte(moment().unix()) &&
+        BigNumber(nft.lockEnds).gte(dayjs().unix()) &&
         BigNumber(nft.lockEnds).gt(0) && (
           <ExistingLock nft={nft} govToken={govToken} veToken={veToken} />
         )}
       {router.query.id !== "create" &&
         nft &&
-        BigNumber(nft.lockEnds).lt(moment().unix()) &&
+        BigNumber(nft.lockEnds).lt(dayjs().unix()) &&
         BigNumber(nft.lockEnds).gt(0) && (
           <Unlock nft={nft} govToken={govToken} veToken={veToken} />
         )}

--- a/Frontend-v1-Original/components/ssVest/vestingInfo.tsx
+++ b/Frontend-v1-Original/components/ssVest/vestingInfo.tsx
@@ -1,10 +1,13 @@
 import { Typography } from "@mui/material";
-import moment from "moment";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 
 import { formatCurrency } from "../../utils/utils";
 import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
 
 import classes from "./ssVest.module.css";
+
+dayjs.extend(relativeTime);
 
 interface VestingInfoProps {
   veToken: VeToken | null;
@@ -39,7 +42,7 @@ export default function VestingInfo({
                 className={classes.val}
               >
                 {formatCurrency(currentNFT.lockAmount)} {govToken?.symbol}{" "}
-                locked expires {moment.unix(+currentNFT?.lockEnds).fromNow()}{" "}
+                locked expires {dayjs.unix(+currentNFT?.lockEnds).fromNow()}{" "}
               </Typography>
               <Typography
                 color="textSecondary"
@@ -47,7 +50,7 @@ export default function VestingInfo({
                 className={classes.val}
               >
                 Locked until{" "}
-                {moment.unix(+currentNFT?.lockEnds).format("YYYY / MM / DD")}
+                {dayjs.unix(+currentNFT?.lockEnds).format("YYYY / MM / DD")}
               </Typography>
             </div>
           </div>
@@ -69,7 +72,7 @@ export default function VestingInfo({
                 className={classes.val}
               >
                 {formatCurrency(futureNFT.lockAmount)} {govToken?.symbol} locked
-                expires {moment.unix(+futureNFT?.lockEnds).fromNow()}{" "}
+                expires {dayjs.unix(+futureNFT?.lockEnds).fromNow()}{" "}
               </Typography>
               <Typography
                 color="textSecondary"
@@ -77,7 +80,7 @@ export default function VestingInfo({
                 className={classes.val}
               >
                 Locked until{" "}
-                {moment.unix(+futureNFT?.lockEnds).format("YYYY / MM / DD")}
+                {dayjs.unix(+futureNFT?.lockEnds).format("YYYY / MM / DD")}
               </Typography>
             </div>
           </div>

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -30,7 +30,8 @@ import {
   Merge,
   TrendingUp,
 } from "@mui/icons-material";
-import moment from "moment";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 import BigNumber from "bignumber.js";
 import Link from "next/link";
 
@@ -38,7 +39,7 @@ import stores from "../../stores";
 import { formatCurrency } from "../../utils/utils";
 import { ACTIONS } from "../../stores/constants/constants";
 import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
-
+dayjs.extend(relativeTime);
 const headCells = [
   { id: "NFT", numeric: false, disablePadding: false, label: "NFT" },
   {
@@ -456,14 +457,14 @@ function MyTableRow(props: {
       </TableCell>
       <TableCell align="right">
         <Typography variant="h2" className="text-xs font-extralight">
-          {moment.unix(+row.lockEnds).format("YYYY-MM-DD")}
+          {dayjs.unix(+row.lockEnds).format("YYYY-MM-DD")}
         </Typography>
         <Typography
           variant="h5"
           className="text-xs font-extralight"
           color="textSecondary"
         >
-          Expires {moment.unix(+row.lockEnds).fromNow()}
+          Expires {dayjs.unix(+row.lockEnds).fromNow()}
         </Typography>
       </TableCell>
       <TableCell align="right">

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-import": "^2.27.5",
     "flux": "^4.0.3",
     "lottie-react": "^2.2.1",
-    "moment": "^2.29.1",
     "next": "12.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query-devtools": "^4.29.6",
     "bignumber.js": "^9.0.1",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.8",
     "eslint-plugin-import": "^2.27.5",
     "flux": "^4.0.3",
     "lottie-react": "^2.2.1",

--- a/Frontend-v1-Original/stores/stableSwapStore.ts
+++ b/Frontend-v1-Original/stores/stableSwapStore.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "events";
 
-import moment from "moment";
+import dayjs from "dayjs";
 import { v4 as uuidv4 } from "uuid";
 import BigNumber from "bignumber.js";
 
@@ -2319,7 +2319,7 @@ class Store {
       const sendAmount1 = BigNumber(amount1)
         .times(10 ** token1.decimals)
         .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amount0)
         .times(sendSlippage)
         .times(10 ** token0.decimals)
@@ -2592,7 +2592,7 @@ class Store {
       const sendAmount1 = BigNumber(amount1)
         .times(10 ** token1.decimals)
         .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amount0)
         .times(sendSlippage)
         .times(10 ** token0.decimals)
@@ -2799,7 +2799,7 @@ class Store {
       const sendAmount1 = BigNumber(amount1)
         .times(10 ** token1.decimals)
         .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amount0)
         .times(sendSlippage)
         .times(10 ** token0.decimals)
@@ -3104,7 +3104,7 @@ class Store {
       const sendAmount1 = BigNumber(amount1)
         .times(10 ** token1.decimals)
         .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amount0)
         .times(sendSlippage)
         .times(10 ** token0.decimals)
@@ -3450,7 +3450,7 @@ class Store {
       });
 
       const sendSlippage = BigNumber(100).minus(slippage).div(100);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amountA.toString())
         .times(sendSlippage)
         .toFixed(0);
@@ -3568,7 +3568,7 @@ class Store {
       const sendAmount = BigNumber(amount)
         .times(10 ** PAIR_DECIMALS)
         .toFixed(0);
-      const deadline = "" + moment().add(600, "seconds").unix();
+      const deadline = "" + dayjs().add(600, "seconds").unix();
       const sendAmount0Min = BigNumber(amount0)
         .times(sendSlippage)
         .times(10 ** token0.decimals)
@@ -4244,8 +4244,8 @@ class Store {
       let allowanceTXID = this.getTXUUID();
       let vestTXID = this.getTXUUID();
 
-      const unlockString = moment()
-        .add(unlockTime, "seconds")
+      const unlockString = dayjs()
+        .add(+unlockTime, "seconds")
         .format("YYYY-MM-DD");
 
       this.emitter.emit(ACTIONS.TX_ADDED, {

--- a/Frontend-v1-Original/yarn.lock
+++ b/Frontend-v1-Original/yarn.lock
@@ -4553,11 +4553,6 @@ minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
-moment@^2.29.1:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 motion@10.16.2:
   version "10.16.2"
   resolved "https://registry.yarnpkg.com/motion/-/motion-10.16.2.tgz#7dc173c6ad62210a7e9916caeeaf22c51e598d21"

--- a/Frontend-v1-Original/yarn.lock
+++ b/Frontend-v1-Original/yarn.lock
@@ -2806,6 +2806,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dayjs@^1.11.8:
+  version "1.11.8"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
+  integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
Same as https://github.com/Velocimeter/frontend/pull/125, but apply to canto-v2 branch.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the `moment` library with the `dayjs` library for date and time calculations in the frontend. 

### Detailed summary
- Replaced all imports of `moment` with `dayjs` in frontend components and stores
- Updated all relevant code to use `dayjs` functions instead of `moment` functions for date and time calculations

> The following files were skipped due to too many changes: `Frontend-v1-Original/components/ssVest/lockDuration.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->