### PR TITLE
change def slippage

### DIFF
--- a/Frontend-v1-Original/components/ssSwap/setup.tsx
+++ b/Frontend-v1-Original/components/ssSwap/setup.tsx
@@ -60,7 +60,7 @@ function Setup() {
   const [toAssetError, setToAssetError] = useState<string | false>(false);
   const [toAssetOptions, setToAssetOptions] = useState<BaseAsset[]>([]);
 
-  const [slippage, setSlippage] = useState("2");
+  const [slippage, setSlippage] = useState("0.5");
   const [slippageError] = useState(false);
 
   const [quoteError, setQuoteError] = useState<string | null | false>(null);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the default slippage value in the `ssSwap` component from 2 to 0.5.

### Detailed summary
- Updated the default slippage value in `setup.tsx` from "2" to "0.5".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->