### PR TITLE
fix max buttons on vest and liq tabs

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useAmountToPay.ts
+++ b/Frontend-v1-Original/components/options/lib/useAmountToPay.ts
@@ -1,4 +1,4 @@
-import { formatEther, formatUnits, parseEther } from "viem";
+import { formatUnits, parseEther } from "viem";
 
 import {
   useOptionTokenGetDiscountedPrice,
@@ -41,7 +41,8 @@ export function useAmountToPayLiquid() {
           activeInput === INPUT.PAYMENT
         ) {
           const amountOptionForPayment =
-            parseFloat(payment) / parseFloat(formatEther(oneOptionPrice));
+            parseFloat(payment) /
+            parseFloat(formatUnits(oneOptionPrice, paymentTokenDecimals));
           setOption(amountOptionForPayment.toString());
         }
       },
@@ -84,7 +85,8 @@ export function useAmountToPayVest() {
           activeInput === INPUT.PAYMENT
         ) {
           const amountOptionForPayment =
-            parseFloat(payment) / parseFloat(formatEther(oneOptionPrice));
+            parseFloat(payment) /
+            parseFloat(formatUnits(oneOptionPrice, paymentTokenDecimals));
           setOption(amountOptionForPayment.toString());
         }
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for token decimals in the `useAmountToPay` functions of the `options` component.

### Detailed summary
- Import `formatUnits` and `parseEther` from `viem`.
- Use `formatUnits` instead of `formatEther` to support token decimals.
- Update `useAmountToPayLiquid` and `useAmountToPayVest` functions to use `formatUnits` with `paymentTokenDecimals`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->