### PR TITLE
fix displayed usdc reward 

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useStakeData.ts
+++ b/Frontend-v1-Original/components/options/lib/useStakeData.ts
@@ -50,7 +50,7 @@ export function useStakeData() {
   });
 
   const { paymentTokenDecimals, paymentTokenAddress } = useTokenData();
-  const { data: paymentTokenBalanceInGauge } = useMaxxingGaugeLeft({
+  const { data: paymentTokenLeftInGauge } = useMaxxingGaugeLeft({
     args: [paymentTokenAddress!],
     enabled: !!paymentTokenAddress,
     select: (data) => formatUnits(data, paymentTokenDecimals),
@@ -77,8 +77,8 @@ export function useStakeData() {
     stakedBalanceWithLock,
     stakedLockEnd,
     paymentTokenBalanceToDistribute:
-      paymentTokenBalanceInOption && paymentTokenBalanceInGauge
-        ? parseFloat(paymentTokenBalanceInGauge) +
+      paymentTokenBalanceInOption && paymentTokenLeftInGauge
+        ? parseFloat(paymentTokenLeftInGauge) +
           parseFloat(paymentTokenBalanceInOption.formatted)
         : undefined,
     refetch: () => {

--- a/Frontend-v1-Original/components/options/lib/useStakeData.ts
+++ b/Frontend-v1-Original/components/options/lib/useStakeData.ts
@@ -1,19 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAccount, useBalance } from "wagmi";
-import { formatEther } from "viem";
+import { formatEther, formatUnits } from "viem";
 
 import {
   useMaxxingGaugeBalanceOf,
   useMaxxingGaugeBalanceWithLock,
+  useMaxxingGaugeLeft,
   useMaxxingGaugeLockEnd,
   useMaxxingGaugeStake,
   useMaxxingGaugeTotalSupply,
-  useOptionTokenPaymentToken,
 } from "../../../lib/wagmiGen";
 import { useGetPair } from "../../liquidityManage/lib/queries";
 import { Pair } from "../../../stores/types/types";
 import { useTokenPrices } from "../../header/lib/queries";
 import { PRO_OPTIONS } from "../../../stores/constants/constants";
+
+import { useTokenData } from "./useTokenData";
 
 export function useStakeData() {
   const { address } = useAccount();
@@ -47,9 +49,14 @@ export function useStakeData() {
     select: (data) => Number(data),
   });
 
-  const { data: paymentTokenAddress } = useOptionTokenPaymentToken();
-  const { data: paymentTokenBalanceInGauge } = useBalance({
-    address: PRO_OPTIONS.oFLOW.gaugeAddress,
+  const { paymentTokenDecimals, paymentTokenAddress } = useTokenData();
+  const { data: paymentTokenBalanceInGauge } = useMaxxingGaugeLeft({
+    args: [paymentTokenAddress!],
+    enabled: !!paymentTokenAddress,
+    select: (data) => formatUnits(data, paymentTokenDecimals),
+  });
+  const { data: paymentTokenBalanceInOption } = useBalance({
+    address: PRO_OPTIONS.oFLOW.tokenAddress,
     token: paymentTokenAddress,
     enabled: !!paymentTokenAddress,
   });
@@ -69,7 +76,11 @@ export function useStakeData() {
     stakedBalanceWithoutLock: stakedBalanceWithoutLock?.toString(),
     stakedBalanceWithLock,
     stakedLockEnd,
-    paymentTokenBalanceInGauge,
+    paymentTokenBalanceToDistribute:
+      paymentTokenBalanceInOption && paymentTokenBalanceInGauge
+        ? parseFloat(paymentTokenBalanceInGauge) +
+          parseFloat(paymentTokenBalanceInOption.formatted)
+        : undefined,
     refetch: () => {
       refetchPooledBalance();
       refetchStakedBalance();

--- a/Frontend-v1-Original/components/options/lib/useTokenData.ts
+++ b/Frontend-v1-Original/components/options/lib/useTokenData.ts
@@ -78,6 +78,7 @@ export function useTokenData(lpDiscount?: number) {
     paymentTokenSymbol: paymentTokenSymbol ?? "WPLS",
     paymentTokenDecimals: paymentTokenDecimals ?? 18,
     underlyingTokenSymbol: underlyingTokenSymbol ?? "FLOW",
+    paymentTokenAddress,
     paymentBalance,
     optionBalance,
     optionPrice,

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -51,7 +51,7 @@ export function Stake() {
     stakedBalanceWithLock,
     stakedLockEnd,
     totalStakedValue,
-    paymentTokenBalanceInGauge,
+    paymentTokenBalanceToDistribute,
   } = useStakeData();
   const { data: aprRange } = useGaugeApr();
 
@@ -215,9 +215,7 @@ export function Stake() {
         </div>
         <div className="flex items-center justify-between">
           <div>{paymentTokenSymbol} reward in gauge</div>
-          <div>
-            ${formatCurrency(paymentTokenBalanceInGauge?.formatted ?? 0)}
-          </div>
+          <div>${formatCurrency(paymentTokenBalanceToDistribute ?? 0)}</div>
         </div>
         <div className="flex items-center justify-between">
           <div>Pooled balance</div>


### PR DESCRIPTION
to show left in gauge instead of balance + what awaits in option token

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `paymentTokenBalanceToDistribute` variable and updates the `useTokenData` function to handle token data. 

### Detailed summary
- Adds `paymentTokenBalanceToDistribute` variable to `Stake` component
- Updates `useTokenData` function to handle token data
- Replaces `formatEther` with `formatUnits` in `useStakeData` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->