### PR TITLE
fix allowance hook select error

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useAllowance.ts
+++ b/Frontend-v1-Original/components/options/lib/useAllowance.ts
@@ -1,5 +1,5 @@
 import { useAccount, useWaitForTransaction } from "wagmi";
-import { formatUnits, parseUnits } from "viem";
+import { parseUnits } from "viem";
 
 import {
   useErc20Allowance,
@@ -27,9 +27,10 @@ export function useAllowance() {
   } = useErc20Allowance({
     address: paymentTokenAddress,
     args: [address!, PRO_OPTIONS.oFLOW.tokenAddress],
-    enabled: !!address && !!paymentTokenAddress,
+    enabled: !!address && !!paymentTokenAddress && !!paymentTokenDecimals,
     select: (allowance) => {
       if (!maxPayment) return;
+      if (!isValidInput(maxPayment, paymentTokenDecimals)) return;
       return allowance < parseUnits(maxPayment, paymentTokenDecimals);
     },
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `formatUnits` import and adds a check for valid input in the `useAllowance` function.

### Detailed summary
- Removed `formatUnits` import from `viem`.
- Added a check for valid input in `useAllowance` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->