### PR TITLE
set minimum lock date

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -153,9 +153,7 @@ export default function Lock({
               onChange={amountChanged}
               disabled={lockLoading}
               inputProps={{
-                min: dayjs()
-                  .add(lockOptions["6.5 weeks"], "days")
-                  .format("YYYY-MM-DD"),
+                min: dayjs().add(3, "days").format("YYYY-MM-DD"),
                 max: dayjs()
                   .add(lockOptions["26 weeks"], "days")
                   .format("YYYY-MM-DD"),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `min` value of a date input field in the `lock.tsx` component.

### Detailed summary
- Updated `min` value of date input field to `dayjs().add(3, "days").format("YYYY-MM-DD")`
- Removed previous calculation based on `lockOptions["6.5 weeks"]`
- No other notable changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->