### PR TITLE
more UI updates for options

### DIFF
--- a/Frontend-v1-Original/components/options/convert.tsx
+++ b/Frontend-v1-Original/components/options/convert.tsx
@@ -106,9 +106,11 @@ export function Convert() {
   return (
     <>
       <div className="flex w-96 min-w-[384px] flex-col rounded-md border border-cyan/50 p-5 font-sono text-lime-50 md:w-[512px] md:min-w-[512px]">
-        <div className="flex items-center justify-between">
-          <div>oFLOW v1 balance</div>
-          <div>{formatCurrency(optionV1Balance?.formatted)}</div>
+        <div className="relative mb-5 flex items-center justify-between">
+          <h2 className="text-xl">oFLOW v1 balance</h2>
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 text-sm">
+            {formatCurrency(optionV1Balance?.formatted)}
+          </div>
         </div>
         <div className="my-5 flex flex-col gap-3">
           <div className="flex items-center justify-between">

--- a/Frontend-v1-Original/components/options/redeem.tsx
+++ b/Frontend-v1-Original/components/options/redeem.tsx
@@ -83,9 +83,7 @@ export function Redeem() {
       value={tab}
       onValueChange={handleTabChange}
     >
-      <h1 className="mb-5 text-center text-xl">
-        Redeem {optionTokenSymbol} Into
-      </h1>
+      <h2 className="mb-5 text-xl">Redeem {optionTokenSymbol} Into</h2>
       <Tabs.List className="flex shrink-0" aria-label="Redeem options">
         {Object.values(TABS).map((tab) => (
           <Tabs.Trigger

--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -46,45 +46,68 @@ export function Reward() {
     },
   });
 
+  console.log("earnedRewards", earnedRewards);
+
   return (
     <div className="flex w-96 min-w-[384px] flex-col rounded-md border border-cyan/50 p-5 font-sono text-lime-50 md:w-[512px] md:min-w-[512px]">
-      <div className="flex items-center justify-between">
-        <div>Earned</div>
-        {isLoadingGaugeRewards && <div>Loading...</div>}
-        {isRefetchingGaugeRewards && <div>Updating...</div>}
-      </div>
-      {earnedRewards &&
-        earnedRewards.length > 0 &&
-        earnedRewards.map((earnedReward) => (
-          <div
-            className="flex items-center justify-between"
-            key={earnedReward.address}
-          >
-            {formatCurrency(earnedReward.earnedAmount)}{" "}
-            {earnedReward.symbol === underlyingTokenSymbol
-              ? `o${underlyingTokenSymbol}`
-              : earnedReward.symbol}
+      <div className="relative mb-5 flex items-center justify-between">
+        <h2 className="text-xl">Earned</h2>
+        {isLoadingGaugeRewards && (
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 text-sm">
+            Loading...
           </div>
-        ))}
+        )}
+        {isRefetchingGaugeRewards && (
+          <div
+            className="
+          absolute
+          right-0
+          top-1/2
+          -translate-y-1/2
+          text-sm
+        "
+          >
+            Updating...
+          </div>
+        )}
+      </div>
+      {earnedRewards && earnedRewards.length > 0 && (
+        <div className="space-y-1">
+          {earnedRewards.map((earnedReward) => (
+            <div
+              className="flex items-center justify-between space-y-2"
+              key={earnedReward.address}
+            >
+              {formatCurrency(earnedReward.earnedAmount)}{" "}
+              {earnedReward.symbol === underlyingTokenSymbol
+                ? `o${underlyingTokenSymbol}`
+                : earnedReward.symbol}
+            </div>
+          ))}
+        </div>
+      )}
       {earnedRewards && earnedRewards.length === 0 && (
         <div className="flex items-center justify-between">
           Nothing earned yet
         </div>
       )}
-      <button
-        disabled={
-          isFetchingGaugeRewards ||
-          isWritingGetReward ||
-          waitingGetRewardReceipt ||
-          !getReward
-        }
-        onClick={() => getReward?.()}
-        className="flex h-14 w-full items-center justify-center rounded border border-transparent bg-cyan p-5 text-center font-medium text-black transition-colors hover:bg-cyan/80 focus-visible:outline-secondary disabled:bg-slate-400 disabled:opacity-60"
-      >
-        {isWritingGetReward || waitingGetRewardReceipt
-          ? "Loading..."
-          : "Claim Rewards"}
-      </button>
+      <div className="block h-3"></div>
+      <div>
+        <button
+          disabled={
+            isFetchingGaugeRewards ||
+            isWritingGetReward ||
+            waitingGetRewardReceipt ||
+            !getReward
+          }
+          onClick={() => getReward?.()}
+          className="flex h-14 w-full items-center justify-center rounded border border-transparent bg-cyan p-5 text-center font-medium text-black transition-colors hover:bg-cyan/80 focus-visible:outline-secondary disabled:bg-slate-400 disabled:opacity-60"
+        >
+          {isWritingGetReward || waitingGetRewardReceipt
+            ? "Claiming..."
+            : "Claim Rewards"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -177,9 +177,9 @@ export function Stake() {
   return (
     <>
       <div className="flex w-96 min-w-[384px] flex-col rounded-md border border-cyan/50 p-5 font-sono text-lime-50 md:w-[512px] md:min-w-[512px]">
-        <div className="flex cursor-pointer items-center">
+        <h2 className="mb-5 flex cursor-pointer items-center text-xl">
           <label
-            className="pr-[15px] text-[15px] leading-none text-white"
+            className="pr-[15px] leading-none text-white"
             htmlFor="airplane-mode"
           >
             Stake
@@ -193,12 +193,12 @@ export function Stake() {
             <Switch.Thumb className="block h-[21px] w-[21px] translate-x-0.5 rounded-full bg-white shadow-[0_2px_2px] shadow-black transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
           </Switch.Root>
           <label
-            className="pl-[15px] text-[15px] leading-none text-white"
+            className="pl-[15px] leading-none text-white"
             htmlFor="airplane-mode"
           >
             Withdraw
           </label>
-        </div>
+        </h2>
         <div className="flex items-center justify-between">
           <div>Total staked</div>
           <div>${formatCurrency(totalStakedValue)}</div>
@@ -217,34 +217,36 @@ export function Stake() {
           <div>{paymentTokenSymbol} reward in gauge</div>
           <div>${formatCurrency(paymentTokenBalanceToDistribute ?? 0)}</div>
         </div>
-        <div className="flex items-center justify-between">
-          <div>Pooled balance</div>
-          <div>{pooledBalance?.formatted}</div>
-        </div>
+
         <div className="flex items-center justify-between">
           <div>Staked without lock</div>
           <div
             className={`${action === ACTION.WITHDRAW && "cursor-pointer"}`}
             onClick={() => pickWithdrawAmount("notLocked")}
           >
-            {formatCurrency(stakedBalanceWithoutLock)}
+            {stakedBalanceWithoutLock}
           </div>
+        </div>
+        <div className="flex flex-col">
+          <div className="flex items-center justify-between">
+            <div>Staked with lock</div>
+            <div
+              className={`${action === ACTION.WITHDRAW && "cursor-pointer"}`}
+              onClick={() => pickWithdrawAmount("locked")}
+            >
+              {stakedBalanceWithLock}
+            </div>
+          </div>
+          {stakedLockEnd && (
+            <div className="text-right">
+              {dayjs.unix(stakedLockEnd).format("YYYY-MM-DD HH:mm:ss")}
+            </div>
+          )}
         </div>
         <div className="flex items-center justify-between">
-          <div>Staked with lock</div>
-          <div
-            className={`${action === ACTION.WITHDRAW && "cursor-pointer"}`}
-            onClick={() => pickWithdrawAmount("locked")}
-          >
-            {formatCurrency(stakedBalanceWithLock)}
-          </div>
+          <div>Pooled balance</div>
+          <div>{pooledBalance?.formatted}</div>
         </div>
-        {stakedLockEnd && (
-          <div className="flex items-center justify-between">
-            <div>Lock end</div>
-            <div>{dayjs.unix(stakedLockEnd).fromNow()}</div>
-          </div>
-        )}
         <div className="my-5 flex flex-col gap-3">
           <div className="flex items-center justify-between">
             <div className="w-full border border-[rgb(46,45,45)]">

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -227,22 +227,21 @@ export function Stake() {
             {stakedBalanceWithoutLock}
           </div>
         </div>
-        <div className="flex flex-col">
-          <div className="flex items-center justify-between">
-            <div>Staked with lock</div>
-            <div
-              className={`${action === ACTION.WITHDRAW && "cursor-pointer"}`}
-              onClick={() => pickWithdrawAmount("locked")}
-            >
-              {stakedBalanceWithLock}
-            </div>
+        <div className="flex items-center justify-between">
+          <div>Staked with lock</div>
+          <div
+            className={`${action === ACTION.WITHDRAW && "cursor-pointer"}`}
+            onClick={() => pickWithdrawAmount("locked")}
+          >
+            {stakedBalanceWithLock}
           </div>
-          {stakedLockEnd && (
-            <div className="text-right">
-              {dayjs.unix(stakedLockEnd).format("YYYY-MM-DD HH:mm:ss")}
-            </div>
-          )}
         </div>
+        {stakedLockEnd ? (
+          <div className="flex items-center justify-between">
+            <div>Lock end</div>
+            <div>{dayjs.unix(stakedLockEnd).format("YYYY-MM-DD HH:mm:ss")}</div>
+          </div>
+        ) : null}
         <div className="flex items-center justify-between">
           <div>Pooled balance</div>
           <div>{pooledBalance?.formatted}</div>


### PR DESCRIPTION
Unify the styles of headers.

<img width="1129" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/32b35b4e-4bc7-42e8-a6c1-6f84ca4b5349">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the UI of several components in the frontend by changing the styling and layout of certain elements.

### Detailed summary
- Updated the styling and layout of the "Redeem" component's title
- Changed the layout of the "oFLOW v1 balance" section in the "Convert" component
- Updated the styling and layout of the "Stake" component's title and certain elements within it
- Updated the styling and layout of the "Earned" section in the "Reward" component, added loading state and disabled button while claiming rewards

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->