### PR TITLE
show apr separately for each token

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
+++ b/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
@@ -127,6 +127,5 @@ function getGaugeApr(
       map.set(rewardToken, [apr, apr] as const);
     }
   }
-  console.log(map);
   return map;
 }

--- a/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
+++ b/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
@@ -134,9 +134,7 @@ function getGaugeApr(
   const arr = [];
 
   for (const [token, aprRange] of map) {
-    if (aprRange[0] === aprRange[1]) {
-      arr.push({ ...token, apr: aprRange[0] });
-    } else if (aprRange[1] < 0.01) {
+    if (aprRange[0] === aprRange[1] || aprRange[1] < 0.01) {
       arr.push({ ...token, apr: aprRange[0] });
     } else {
       arr.push({ ...token, aprRange });

--- a/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
+++ b/Frontend-v1-Original/components/options/lib/useGaugeApr.ts
@@ -101,15 +101,9 @@ function getGaugeApr(
     +veDiscount
   );
 
-  let minApr = 0;
-  let maxApr = 0;
-  let apr = 0;
+  const map = new Map<Token, readonly [number, number]>(); // [minApr, maxApr]
 
   for (const rewardToken of rewardTokens) {
-    let minPrice: number | undefined;
-    let maxPrice: number | undefined;
-    let price: number | undefined;
-
     if (
       rewardToken.address.toLowerCase() ===
         underlyingTokenAddress.toLowerCase() ||
@@ -118,21 +112,21 @@ function getGaugeApr(
       const fullUnderlyingTokenPrice =
         tokenPrices.get(underlyingTokenAddress.toLowerCase()) ?? 0;
 
-      maxPrice = (fullUnderlyingTokenPrice * (100 - minDiscount)) / 100;
-      minPrice = (fullUnderlyingTokenPrice * (100 - maxDiscount)) / 100;
+      const maxPrice = (fullUnderlyingTokenPrice * (100 - minDiscount)) / 100;
+      const minPrice = (fullUnderlyingTokenPrice * (100 - maxDiscount)) / 100;
 
-      maxApr +=
+      const maxApr =
         ((rewardToken.reward * maxPrice) / totalStakedValue) * 100 * 365;
-      minApr +=
+      const minApr =
         ((rewardToken.reward * minPrice) / totalStakedValue) * 100 * 365;
+
+      map.set(rewardToken, [minApr, maxApr] as const);
     } else {
-      price = tokenPrices.get(rewardToken.address.toLowerCase()) ?? 0;
-      apr += ((rewardToken.reward * price) / totalStakedValue) * 100 * 365;
+      const price = tokenPrices.get(rewardToken.address.toLowerCase()) ?? 0;
+      const apr = ((rewardToken.reward * price) / totalStakedValue) * 100 * 365;
+      map.set(rewardToken, [apr, apr] as const);
     }
   }
-
-  minApr += apr;
-  maxApr += apr;
-
-  return [minApr, maxApr] as const;
+  console.log(map);
+  return map;
 }

--- a/Frontend-v1-Original/components/options/redeem.tsx
+++ b/Frontend-v1-Original/components/options/redeem.tsx
@@ -14,7 +14,6 @@ import dayjs from "dayjs";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as Checkbox from "@radix-ui/react-checkbox";
-import * as Separator from "@radix-ui/react-separator";
 
 import { formatCurrency } from "../../utils/utils";
 import { QUERY_KEYS } from "../../stores/constants/constants";

--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -46,8 +46,6 @@ export function Reward() {
     },
   });
 
-  console.log("earnedRewards", earnedRewards);
-
   return (
     <div className="flex w-96 min-w-[384px] flex-col rounded-md border border-cyan/50 p-5 font-sono text-lime-50 md:w-[512px] md:min-w-[512px]">
       <div className="relative mb-5 flex items-center justify-between">

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -64,8 +64,9 @@ export function Stake() {
     const arr = [];
 
     for (const [token, aprRange] of aprMap.entries()) {
-      console.log(token, aprRange);
       if (aprRange[0] === aprRange[1]) {
+        arr.push({ ...token, apr: aprRange[0] });
+      } else if (aprRange[0] < 0.01 && aprRange[1] < 0.01) {
         arr.push({ ...token, apr: aprRange[0] });
       } else {
         arr.push({ ...token, aprRange });

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -22,13 +22,7 @@ import {
   usePrepareErc20Approve,
 } from "../../lib/wagmiGen";
 
-import {
-  isValidInput,
-  useStakeData,
-  useGaugeApr,
-  useTokenData,
-  useGaugeRewardTokens,
-} from "./lib";
+import { isValidInput, useStakeData, useGaugeApr, useTokenData } from "./lib";
 
 const ACTION = {
   STAKE: "STAKE",
@@ -61,23 +55,25 @@ export function Stake() {
     totalStakedValue,
     paymentTokenBalanceToDistribute,
   } = useStakeData();
-  const { data: aprRange } = useGaugeApr();
-  const { data: rewardTokens } = useGaugeRewardTokens();
+
+  const { data: aprMap } = useGaugeApr();
+
   const displayedRewardTokens = useMemo(() => {
-    if (!rewardTokens) return undefined;
-    const tokenLogosSet = new Set<string>();
+    if (!aprMap) return undefined;
+
     const arr = [];
-    for (const token of rewardTokens) {
-      if (token.logoUrl !== undefined && tokenLogosSet.has(token.logoUrl)) {
-        continue;
-      } else if (token.logoUrl !== undefined) {
-        tokenLogosSet.add(token.logoUrl);
+
+    for (const [token, aprRange] of aprMap.entries()) {
+      console.log(token, aprRange);
+      if (aprRange[0] === aprRange[1]) {
+        arr.push({ ...token, apr: aprRange[0] });
+      } else {
+        arr.push({ ...token, aprRange });
       }
-      arr.push(token);
     }
 
     return arr;
-  }, [rewardTokens]);
+  }, [aprMap]);
 
   const {
     data: isApprovalNeeded,
@@ -227,35 +223,40 @@ export function Stake() {
           <div>Total staked</div>
           <div>${formatCurrency(totalStakedValue)}</div>
         </div>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center justify-start gap-2">
-            <div>APR</div>
-            {displayedRewardTokens && displayedRewardTokens.length > 0 && (
-              <div className="flex items-center justify-center gap-1">
-                {displayedRewardTokens.map((token) => (
+        <div className="my-1 flex items-center justify-between">
+          <div>APR</div>
+          <div className="flex flex-col">
+            {displayedRewardTokens && displayedRewardTokens.length > 0 ? (
+              displayedRewardTokens.map((token) => (
+                <div
+                  key={token.address}
+                  className="flex items-center justify-end gap-2"
+                >
+                  <div>
+                    {"aprRange" in token
+                      ? `${formatCurrency(
+                          token.aprRange[0]
+                        )} % - ${formatCurrency(token.aprRange[1])} %`
+                      : `
+                  ${formatCurrency(token.apr)} %
+                  `}
+                  </div>
                   <img
-                    key={token.address}
                     src={token.logoUrl ?? "/tokens/unknown-logo.png"}
                     alt={`${token.symbol} logo`}
-                    className="h-5 w-5 rounded-full"
+                    className="block h-5 w-5 rounded-full"
                   />
-                ))}
-              </div>
+                </div>
+              ))
+            ) : (
+              <div>0.00</div>
             )}
-          </div>
-          <div>
-            {aprRange
-              ? `${formatCurrency(aprRange[0])} % - ${formatCurrency(
-                  aprRange[1]
-                )} %`
-              : `0 % - 0 %`}
           </div>
         </div>
         <div className="flex items-center justify-between">
           <div>{paymentTokenSymbol} reward</div>
           <div>${formatCurrency(paymentTokenBalanceToDistribute ?? 0)}</div>
         </div>
-
         <div className="flex items-center justify-between">
           <div>Staked without lock</div>
           <div

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   useAccount,
   useNetwork,
@@ -56,25 +56,7 @@ export function Stake() {
     paymentTokenBalanceToDistribute,
   } = useStakeData();
 
-  const { data: aprMap } = useGaugeApr();
-
-  const displayedRewardTokens = useMemo(() => {
-    if (!aprMap) return undefined;
-
-    const arr = [];
-
-    for (const [token, aprRange] of aprMap.entries()) {
-      if (aprRange[0] === aprRange[1]) {
-        arr.push({ ...token, apr: aprRange[0] });
-      } else if (aprRange[0] < 0.01 && aprRange[1] < 0.01) {
-        arr.push({ ...token, apr: aprRange[0] });
-      } else {
-        arr.push({ ...token, aprRange });
-      }
-    }
-
-    return arr;
-  }, [aprMap]);
+  const { data: tokenAprs } = useGaugeApr();
 
   const {
     data: isApprovalNeeded,
@@ -224,11 +206,11 @@ export function Stake() {
           <div>Total staked</div>
           <div>${formatCurrency(totalStakedValue)}</div>
         </div>
-        <div className="my-1 flex items-center justify-between">
+        <div className="flex items-start justify-between">
           <div>APR</div>
           <div className="flex flex-col">
-            {displayedRewardTokens && displayedRewardTokens.length > 0 ? (
-              displayedRewardTokens.map((token) => (
+            {tokenAprs && tokenAprs.length > 0 ? (
+              tokenAprs.map((token) => (
                 <div
                   key={token.address}
                   className="flex items-center justify-end gap-2"
@@ -244,6 +226,7 @@ export function Stake() {
                   </div>
                   <img
                     src={token.logoUrl ?? "/tokens/unknown-logo.png"}
+                    title={token.symbol}
                     alt={`${token.symbol} logo`}
                     className="block h-5 w-5 rounded-full"
                   />

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -22,7 +22,6 @@
     "@mui/lab": "^5.0.0-alpha.116",
     "@mui/material": "^5.11.5",
     "@radix-ui/react-checkbox": "^1.0.4",
-    "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/Frontend-v1-Original/yarn.lock
+++ b/Frontend-v1-Original/yarn.lock
@@ -1754,14 +1754,6 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-controllable-state" "1.0.1"
 
-"@radix-ui/react-separator@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.0.3.tgz#be5a931a543d5726336b112f465f58585c04c8aa"
-  integrity sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@radix-ui/react-primitive" "1.0.3"
-
 "@radix-ui/react-slider@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.1.2.tgz#330ff2a0e1f6c19aace76590004f229a7e8fbe6c"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `@radix-ui/react-separator` package, updates `@mui/material` to version `5.11.5`, and refactors the `useGaugeApr` function to return an array of token objects with their respective APR ranges.

### Detailed summary
- Removes `@radix-ui/react-separator` package.
- Updates `@mui/material` to version `5.11.5`.
- Refactors `useGaugeApr` function to return an array of token objects with their respective APR ranges.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->