### PR TITLE
Feat/GitHub actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,68 @@
+name: PR
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: ./Frontend-v1-Original
+
+jobs:
+  unit_test:
+    name: Unit Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [lts/*]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - run: yarn --frozen-lockfile
+      - run: yarn test
+
+  next_lint:
+    name: Next Lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [lts/*]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - run: yarn --frozen-lockfile
+      - run: yarn lint
+
+  tsc:
+    name: Type Checking
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - run: yarn --frozen-lockfile
+      - run: yarn tsc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+          cache-dependency-path: ./Frontend-v1-Original/yarn.lock
 
       - run: yarn --frozen-lockfile
       - run: yarn test
@@ -46,6 +47,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+          cache-dependency-path: ./Frontend-v1-Original/yarn.lock
 
       - run: yarn --frozen-lockfile
       - run: yarn lint
@@ -64,5 +66,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+          cache-dependency-path: ./Frontend-v1-Original/yarn.lock
       - run: yarn --frozen-lockfile
       - run: yarn tsc


### PR DESCRIPTION
This PR introduces a github action to track the code quality of pull requests. See an example here https://github.com/oxSaturn/frontend/pull/2:

![image](https://github.com/Velocimeter/frontend/assets/126733611/0416d01d-be2a-4742-820e-9c4496e8b329)

Btw, do we still need to keep the `Frontend-v1-Original` folder?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a GitHub Actions workflow for running tests, linting, and type checking on pull requests.

### Detailed summary
- Adds a `pr.yml` file defining a GitHub Actions workflow for pull requests
- Workflow has three jobs: `unit_test`, `next_lint`, and `tsc`
- Each job uses `actions/checkout` to fetch the code, sets up Node.js, installs dependencies, and runs relevant commands (`yarn test`, `yarn lint`, or `yarn tsc`)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->