### PR TITLE
make gauge reactive by reading it from option token

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useGaugeRewards.ts
+++ b/Frontend-v1-Original/components/options/lib/useGaugeRewards.ts
@@ -4,7 +4,10 @@ import { formatUnits } from "viem";
 
 import viemClient from "../../../stores/connectors/viem";
 import { getInitBaseAssets } from "../../../lib/global/queries";
-import { useMaxxingGaugeRewardsListLength } from "../../../lib/wagmiGen";
+import {
+  useMaxxingGaugeRewardsListLength,
+  useOptionTokenGauge,
+} from "../../../lib/wagmiGen";
 import { CONTRACTS, PRO_OPTIONS } from "../../../stores/constants/constants";
 
 const QUERY_KEYS = {
@@ -30,35 +33,46 @@ interface Earned {
 export function useGaugeRewards() {
   const { address } = useAccount();
   const { data: rewardTokens } = useGaugeRewardTokens();
+  const { data: gaugeAddress } = useOptionTokenGauge();
   return useQuery({
-    queryKey: [QUERY_KEYS.EARNED, rewardTokens, address],
-    queryFn: () => getEarned(address, rewardTokens),
-    enabled: !!rewardTokens && !!address,
+    queryKey: [QUERY_KEYS.EARNED, rewardTokens, address, gaugeAddress],
+    queryFn: () => getEarned(address, rewardTokens, gaugeAddress),
+    enabled: !!rewardTokens && !!address && !!gaugeAddress,
     select: filterEarned,
     keepPreviousData: true,
   });
 }
 
 export function useGaugeRewardTokens() {
+  const { data: gaugeAddress } = useOptionTokenGauge();
+
   const { data: rewardsListLength } = useMaxxingGaugeRewardsListLength({
+    address: gaugeAddress,
     select: (data) => Number(data),
   });
+
   return useQuery({
-    queryKey: [QUERY_KEYS.TOKEN_ADDRESSES, rewardsListLength],
-    queryFn: () => getGaugeRewardTokens(rewardsListLength),
-    enabled: !!rewardsListLength,
+    queryKey: [QUERY_KEYS.TOKEN_ADDRESSES, rewardsListLength, gaugeAddress],
+    queryFn: () => getGaugeRewardTokens(rewardsListLength, gaugeAddress),
+    enabled: !!rewardsListLength && !!gaugeAddress,
   });
 }
 
-async function getGaugeRewardTokens(rewardsListLength: number | undefined) {
+async function getGaugeRewardTokens(
+  rewardsListLength: number | undefined,
+  gaugeAddress: Address | undefined
+) {
   if (!rewardsListLength) {
     throw new Error("rewardsListLength is undefined or zero");
+  }
+  if (!gaugeAddress) {
+    throw new Error("gaugeAddress is undefined");
   }
 
   const initBaseAssets = getInitBaseAssets();
 
   const gaugeContract = {
-    address: PRO_OPTIONS.oFVM.gaugeAddress,
+    address: gaugeAddress,
     abi: PRO_OPTIONS.maxxingGaugeABI,
   } as const;
 
@@ -127,7 +141,8 @@ async function getGaugeRewardTokens(rewardsListLength: number | undefined) {
 
 async function getEarned(
   account: Address | undefined,
-  rewardsTokens: Token[] | undefined
+  rewardsTokens: Token[] | undefined,
+  gaugeAddress: Address | undefined
 ) {
   if (!account) {
     throw new Error("account is undefined");
@@ -135,9 +150,12 @@ async function getEarned(
   if (!rewardsTokens) {
     throw new Error("tokenAddresses is undefined");
   }
+  if (!gaugeAddress) {
+    throw new Error("gaugeAddress is undefined");
+  }
 
   const gaugeContract = {
-    address: PRO_OPTIONS.oFVM.gaugeAddress,
+    address: gaugeAddress,
     abi: PRO_OPTIONS.maxxingGaugeABI,
   } as const;
 

--- a/Frontend-v1-Original/components/options/lib/useStakeData.ts
+++ b/Frontend-v1-Original/components/options/lib/useStakeData.ts
@@ -9,6 +9,7 @@ import {
   useMaxxingGaugeLockEnd,
   useMaxxingGaugeStake,
   useMaxxingGaugeTotalSupply,
+  useOptionTokenGauge,
 } from "../../../lib/wagmiGen";
 import { useGetPair } from "../../liquidityManage/lib/queries";
 import { Pair } from "../../../stores/types/types";
@@ -19,8 +20,11 @@ import { useTokenData } from "./useTokenData";
 
 export function useStakeData() {
   const { address } = useAccount();
+  const { data: gaugeAddress } = useOptionTokenGauge();
 
-  const { data: pair } = useMaxxingGaugeStake();
+  const { data: pair } = useMaxxingGaugeStake({
+    address: gaugeAddress,
+  });
   const { data: pooledBalance, refetch: refetchPooledBalance } = useBalance({
     address,
     token: pair,
@@ -28,6 +32,7 @@ export function useStakeData() {
 
   const { data: stakedBalance, refetch: refetchStakedBalance } =
     useMaxxingGaugeBalanceOf({
+      address: gaugeAddress,
       args: [address!],
       enabled: !!address,
       select: (data) => formatEther(data),
@@ -35,12 +40,14 @@ export function useStakeData() {
 
   const { data: stakedBalanceWithLock, refetch: refetchStakedBalanceWithLock } =
     useMaxxingGaugeBalanceWithLock({
+      address: gaugeAddress,
       args: [address!],
       enabled: !!address,
       select: (data) => formatEther(data),
     });
 
   const { data: stakedLockEnd } = useMaxxingGaugeLockEnd({
+    address: gaugeAddress,
     args: [address!],
     enabled:
       !!address &&
@@ -51,6 +58,7 @@ export function useStakeData() {
 
   const { paymentTokenDecimals, paymentTokenAddress } = useTokenData();
   const { data: paymentTokenLeftInGauge } = useMaxxingGaugeLeft({
+    address: gaugeAddress,
     args: [paymentTokenAddress!],
     enabled: !!paymentTokenAddress,
     select: (data) => formatUnits(data, paymentTokenDecimals),
@@ -98,8 +106,12 @@ export function useTotalStaked(
   stakedBalanceWithoutLock: string | undefined,
   stakedBalanceWithLock: string | undefined
 ) {
-  const { data: pair } = useMaxxingGaugeStake();
+  const { data: gaugeAddress } = useOptionTokenGauge();
+  const { data: pair } = useMaxxingGaugeStake({
+    address: gaugeAddress,
+  });
   const { data: totalSupply } = useMaxxingGaugeTotalSupply({
+    address: gaugeAddress,
     select: (data) => formatEther(data),
   });
   const { data: pairData } = useGetPair(pair);

--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from "../../utils/utils";
 import { QUERY_KEYS } from "../../stores/constants/constants";
 import {
   useMaxxingGaugeGetReward,
+  useOptionTokenGauge,
   usePrepareMaxxingGaugeGetReward,
 } from "../../lib/wagmiGen";
 
@@ -28,7 +29,9 @@ export function Reward() {
 
   const { underlyingTokenSymbol } = useTokenData();
 
+  const { data: gaugeAddress } = useOptionTokenGauge();
   const { config: getRewardConfig } = usePrepareMaxxingGaugeGetReward({
+    address: gaugeAddress,
     args: [address!, earnedTokenAddresses!],
     enabled:
       !!address && !!earnedTokenAddresses && earnedTokenAddresses.length > 0,

--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -10,7 +10,6 @@ import { formatEther, parseEther } from "viem";
 import * as Switch from "@radix-ui/react-switch";
 import dayjs from "dayjs";
 
-import { PRO_OPTIONS } from "../../stores/constants/constants";
 import { formatCurrency } from "../../utils/utils";
 import {
   useMaxxingGaugeDeposit,
@@ -20,6 +19,7 @@ import {
   usePrepareMaxxingGaugeDeposit,
   usePrepareMaxxingGaugeWithdraw,
   usePrepareErc20Approve,
+  useOptionTokenGauge,
 } from "../../lib/wagmiGen";
 
 import { isValidInput, useStakeData, useGaugeApr, useTokenData } from "./lib";
@@ -58,14 +58,15 @@ export function Stake() {
 
   const { data: tokenAprs } = useGaugeApr();
 
+  const { data: gaugeAddress } = useOptionTokenGauge();
   const {
     data: isApprovalNeeded,
     refetch: refetchAllowance,
     isFetching: isFetchingAllowance,
   } = useErc20Allowance({
     address: pair,
-    args: [address!, PRO_OPTIONS.oFVM.gaugeAddress],
-    enabled: !!address,
+    args: [address!, gaugeAddress!],
+    enabled: !!address && !!gaugeAddress,
     select: (allowance) => {
       const formattedAllowance = formatEther(allowance);
       if (!amount) return false;
@@ -76,10 +77,15 @@ export function Stake() {
   const { config: approveConfig } = usePrepareErc20Approve({
     address: pair,
     args: [
-      PRO_OPTIONS.oFVM.gaugeAddress,
+      gaugeAddress!,
       isValidInput(amount) ? parseEther(amount as `${number}`) : 0n,
     ],
-    enabled: !!pair && !!address && isApprovalNeeded && isValidInput(amount),
+    enabled:
+      !!pair &&
+      !!address &&
+      !!gaugeAddress &&
+      isApprovalNeeded &&
+      isValidInput(amount),
   });
   const {
     write: approve,
@@ -96,6 +102,7 @@ export function Stake() {
   });
 
   const { config: depositConfig } = usePrepareMaxxingGaugeDeposit({
+    address: gaugeAddress,
     args: [isValidInput(amount) ? parseEther(amount as `${number}`) : 0n, 0n],
     enabled:
       !!address &&
@@ -119,6 +126,7 @@ export function Stake() {
   });
 
   const { config: withdrawConfig } = usePrepareMaxxingGaugeWithdraw({
+    address: gaugeAddress,
     args: [isValidInput(amount) ? parseEther(amount as `${number}`) : 0n],
     enabled: !!address && isValidInput(amount) && action === ACTION.WITHDRAW,
   });

--- a/Frontend-v1-Original/stores/constants/constants.ts
+++ b/Frontend-v1-Original/stores/constants/constants.ts
@@ -34,7 +34,6 @@ export const PRO_OPTIONS = {
   maxxingGaugeABI: maxxingGaugeABI,
   oFVM: {
     tokenAddress: "0x767D9ad09e4E148e0Ae23Ea1F2dB04e5F0Cd2EdA",
-    gaugeAddress: "0x80D1006427c5f6EB662412aeb027d383C5e069cB",
   },
 } as const;
 

--- a/Frontend-v1-Original/wagmi.config.ts
+++ b/Frontend-v1-Original/wagmi.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
     {
       name: "MaxxingGauge",
       abi: PRO_OPTIONS.maxxingGaugeABI,
-      address: PRO_OPTIONS.oFVM.gaugeAddress,
     },
     {
       name: "Convertor",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- This PR focuses on updating the usage of the `useOptionTokenGauge` hook in multiple files.
- The `gaugeAddress` is now passed as a parameter to the `useOptionTokenGauge` hook in the following files:
  - `components/options/reward.tsx`
  - `components/options/stake.tsx`
  - `components/options/lib/useStakeData.ts`
  - `components/options/lib/useGaugeRewards.ts`
- The `useOptionTokenGauge` hook is used to retrieve the `gaugeAddress` data.
- The `gaugeAddress` parameter is used in various configurations and arguments for different functions and hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->