### PR TITLE
update lock durations for fantom

### DIFF
--- a/Frontend-v1-Original/components/options/redeem.tsx
+++ b/Frontend-v1-Original/components/options/redeem.tsx
@@ -14,7 +14,6 @@ import dayjs from "dayjs";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import * as Tabs from "@radix-ui/react-tabs";
 import * as Checkbox from "@radix-ui/react-checkbox";
-import * as Separator from "@radix-ui/react-separator";
 
 import { formatCurrency } from "../../utils/utils";
 import { QUERY_KEYS } from "../../stores/constants/constants";

--- a/Frontend-v1-Original/components/ssVest/existingLock.tsx
+++ b/Frontend-v1-Original/components/ssVest/existingLock.tsx
@@ -9,7 +9,7 @@ import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
 
 import classes from "./ssVest.module.css";
 import LockAmount from "./lockAmount";
-import LockDuration, { lockOptions } from "./lockDuration";
+import LockDuration, { lockOptions, maxLockDuration } from "./lockDuration";
 import VestingInfo from "./vestingInfo";
 
 export default function ExistingLock({
@@ -64,7 +64,7 @@ export default function ExistingLock({
     tmpNFT.lockAmount = BigNumber(nft.lockAmount).plus(amount).toFixed(18);
     tmpNFT.lockValue = BigNumber(tmpNFT.lockAmount)
       .times(parseInt(dayToExpire.toString()) + 1)
-      .div(lockOptions["26 weeks"])
+      .div(lockOptions[maxLockDuration])
       .toFixed(18);
 
     setFutureNFT(tmpNFT);
@@ -89,7 +89,7 @@ export default function ExistingLock({
     tmpNFT.lockEnds = expiry.unix().toString();
     tmpNFT.lockValue = BigNumber(tmpNFT.lockAmount)
       .times(parseInt(dayToExpire.toString()))
-      .div(lockOptions["26 weeks"])
+      .div(lockOptions[maxLockDuration])
       .toFixed(18);
 
     setFutureNFT(tmpNFT);

--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -24,7 +24,12 @@ import { GovToken, VeToken, VestNFT } from "../../stores/types/types";
 import VestingInfo from "./vestingInfo";
 import classes from "./ssVest.module.css";
 
-import { type LockOption, lockOptions } from "./lockDuration";
+import {
+  type LockOption,
+  lockOptions,
+  defaultLockDuration,
+  maxLockDuration,
+} from "./lockDuration";
 import { useCreateVest } from "./lib/mutations";
 
 export default function Lock({
@@ -40,10 +45,10 @@ export default function Lock({
   const [amount, setAmount] = useState("");
   const [amountError, setAmountError] = useState<string | false>(false);
   const [selectedValue, setSelectedValue] = useState<string | null>(
-    lockOptions["6.5 weeks"] + ""
+    lockOptions[defaultLockDuration] + ""
   );
   const [selectedDate, setSelectedDate] = useState(
-    dayjs().add(lockOptions["6.5 weeks"], "days").format("YYYY-MM-DD")
+    dayjs().add(lockOptions[defaultLockDuration], "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
 
@@ -155,7 +160,7 @@ export default function Lock({
               inputProps={{
                 min: dayjs().add(3, "days").format("YYYY-MM-DD"),
                 max: dayjs()
-                  .add(lockOptions["26 weeks"], "days")
+                  .add(lockOptions[maxLockDuration], "days")
                   .format("YYYY-MM-DD"),
               }}
               InputProps={{
@@ -263,7 +268,7 @@ export default function Lock({
       lockAmount: amount,
       lockValue: BigNumber(amount)
         .times(parseInt(dayToExpire.toString()) + 1)
-        .div(lockOptions["26 weeks"])
+        .div(lockOptions[maxLockDuration])
         .toFixed(18),
       lockEnds: expiry.unix().toString(),
       votedInCurrentEpoch: false,

--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -17,12 +17,14 @@ import { VestNFT } from "../../stores/types/types";
 import classes from "./ssVest.module.css";
 import { useIncreaseVestDuration } from "./lib/mutations";
 
-export type LockOption = "6.5 weeks" | "13 weeks" | "19.5 weeks" | "26 weeks";
+export type LockOption = "13 weeks" | "26 weeks" | "39 weeks" | "52 weeks";
+export const defaultLockDuration: LockOption = "13 weeks";
+export const maxLockDuration: LockOption = "52 weeks";
 export const lockOptions: Record<LockOption, number> = {
-  "6.5 weeks": Math.ceil(6.5 * 7),
   "13 weeks": Math.ceil(13 * 7),
-  "19.5 weeks": Math.ceil(19.5 * 7),
   "26 weeks": Math.ceil(26 * 7),
+  "39 weeks": Math.ceil(39 * 7),
+  "52 weeks": Math.ceil(52 * 7),
 };
 
 /**
@@ -47,7 +49,7 @@ export default function LockDuration({
   const inputEl = useRef<HTMLInputElement | null>(null);
 
   const [selectedDate, setSelectedDate] = useState(
-    dayjs().add(lockOptions["6.5 weeks"], "days").format("YYYY-MM-DD")
+    dayjs().add(lockOptions[defaultLockDuration], "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
@@ -142,7 +144,7 @@ export default function LockDuration({
               inputProps={{
                 min: min,
                 max: dayjs()
-                  .add(lockOptions["26 weeks"], "days")
+                  .add(lockOptions[maxLockDuration], "days")
                   .format("YYYY-MM-DD"),
               }}
               InputProps={{
@@ -155,7 +157,7 @@ export default function LockDuration({
     );
   };
 
-  const max = dayjs().add(lockOptions["26 weeks"], "days");
+  const max = dayjs().add(lockOptions[maxLockDuration], "days");
   const roundedDownMax = roundDownToWeekBoundary(max);
   const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
   return (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The PR focuses on making changes to the lock duration functionality in the `ssVest` component.
- It introduces a `defaultLockDuration` and `maxLockDuration` constant in the `lockDuration.tsx` file.
- The `lockOptions` object in `lockDuration.tsx` is updated to include new lock duration options.
- The `Lock` component in `ssVest/lock.tsx` is updated to use the `defaultLockDuration` constant.
- The `LockDuration` component in `ssVest/lockDuration.tsx` is updated to use the `defaultLockDuration` and `maxLockDuration` constants.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->