### PR TITLE
cherry-pick reactive gauge in options

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useStakeData.ts
+++ b/Frontend-v1-Original/components/options/lib/useStakeData.ts
@@ -9,6 +9,7 @@ import {
   useMaxxingGaugeLockEnd,
   useMaxxingGaugeStake,
   useMaxxingGaugeTotalSupply,
+  useOptionTokenGauge,
 } from "../../../lib/wagmiGen";
 import { useGetPair } from "../../liquidityManage/lib/queries";
 import { Pair } from "../../../stores/types/types";
@@ -19,8 +20,11 @@ import { useTokenData } from "./useTokenData";
 
 export function useStakeData() {
   const { address } = useAccount();
+  const { data: gaugeAddress } = useOptionTokenGauge();
 
-  const { data: pair } = useMaxxingGaugeStake();
+  const { data: pair } = useMaxxingGaugeStake({
+    address: gaugeAddress,
+  });
   const { data: pooledBalance, refetch: refetchPooledBalance } = useBalance({
     address,
     token: pair,
@@ -28,6 +32,7 @@ export function useStakeData() {
 
   const { data: stakedBalance, refetch: refetchStakedBalance } =
     useMaxxingGaugeBalanceOf({
+      address: gaugeAddress,
       args: [address!],
       enabled: !!address,
       select: (data) => formatEther(data),
@@ -35,12 +40,14 @@ export function useStakeData() {
 
   const { data: stakedBalanceWithLock, refetch: refetchStakedBalanceWithLock } =
     useMaxxingGaugeBalanceWithLock({
+      address: gaugeAddress,
       args: [address!],
       enabled: !!address,
       select: (data) => formatEther(data),
     });
 
   const { data: stakedLockEnd } = useMaxxingGaugeLockEnd({
+    address: gaugeAddress,
     args: [address!],
     enabled:
       !!address &&
@@ -51,6 +58,7 @@ export function useStakeData() {
 
   const { paymentTokenDecimals, paymentTokenAddress } = useTokenData();
   const { data: paymentTokenLeftInGauge } = useMaxxingGaugeLeft({
+    address: gaugeAddress,
     args: [paymentTokenAddress!],
     enabled: !!paymentTokenAddress,
     select: (data) => formatUnits(data, paymentTokenDecimals),
@@ -98,8 +106,12 @@ export function useTotalStaked(
   stakedBalanceWithoutLock: string | undefined,
   stakedBalanceWithLock: string | undefined
 ) {
-  const { data: pair } = useMaxxingGaugeStake();
+  const { data: gaugeAddress } = useOptionTokenGauge();
+  const { data: pair } = useMaxxingGaugeStake({
+    address: gaugeAddress,
+  });
   const { data: totalSupply } = useMaxxingGaugeTotalSupply({
+    address: gaugeAddress,
     select: (data) => formatEther(data),
   });
   const { data: pairData } = useGetPair(pair);

--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from "../../utils/utils";
 import { QUERY_KEYS } from "../../stores/constants/constants";
 import {
   useMaxxingGaugeGetReward,
+  useOptionTokenGauge,
   usePrepareMaxxingGaugeGetReward,
 } from "../../lib/wagmiGen";
 
@@ -28,7 +29,9 @@ export function Reward() {
 
   const { underlyingTokenSymbol } = useTokenData();
 
+  const { data: gaugeAddress } = useOptionTokenGauge();
   const { config: getRewardConfig } = usePrepareMaxxingGaugeGetReward({
+    address: gaugeAddress,
     args: [address!, earnedTokenAddresses!],
     enabled:
       !!address && !!earnedTokenAddresses && earnedTokenAddresses.length > 0,

--- a/Frontend-v1-Original/stores/constants/constants.ts
+++ b/Frontend-v1-Original/stores/constants/constants.ts
@@ -34,7 +34,6 @@ export const PRO_OPTIONS = {
   maxxingGaugeABI: maxxingGaugeABI,
   oFLOW: {
     tokenAddress: "0x767D9ad09e4E148e0Ae23Ea1F2dB04e5F0Cd2EdA",
-    gaugeAddress: "0x80D1006427c5f6EB662412aeb027d383C5e069cB",
   },
 } as const;
 

--- a/Frontend-v1-Original/wagmi.config.ts
+++ b/Frontend-v1-Original/wagmi.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
     {
       name: "MaxxingGauge",
       abi: PRO_OPTIONS.maxxingGaugeABI,
-      address: PRO_OPTIONS.oFLOW.gaugeAddress,
     },
     {
       name: "Convertor",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The PR focuses on adding the `useOptionTokenGauge` hook to several components in the codebase.
- This hook retrieves the `gaugeAddress` from the `useOptionTokenGauge` hook and uses it in various places to enable functionality related to the gauge address.

Note: Other minor changes and imports have been omitted as per the instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->