### PR TITLE
fix missing price error if price is zero

### DIFF
--- a/Frontend-v1-Original/components/header/lib/queries.ts
+++ b/Frontend-v1-Original/components/header/lib/queries.ts
@@ -192,7 +192,7 @@ const getMarketCap = async (
     throw new Error("Missing circ supply or token prices");
 
   const price = tokenPrices.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase());
-  if (!price) throw new Error("Missing price");
+  if (price === undefined) throw new Error("Missing price");
 
   return circulatingSupply * price;
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Changed the error condition check from `!price` to `price === undefined` in the `queries.ts` file in the `header` component.
- This change ensures that an error is thrown when the price value is `undefined`, indicating a missing price.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->