### PR TITLE
add max lock button

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -47,6 +47,13 @@ function roundDownToWeekBoundary(date: dayjs.Dayjs) {
   return Math.floor(timestamp / WEEK) * WEEK;
 }
 
+export function isNftMaxLocked(nft: VestNFT): boolean {
+  const max = dayjs().add(lockOptions[maxLockDuration], "days");
+  const roundedDownMax = roundDownToWeekBoundary(max);
+  const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
+  return maxLocked; 
+}
+
 export default function LockDuration({
   nft,
   updateLockDuration,
@@ -163,9 +170,7 @@ export default function LockDuration({
     );
   };
 
-  const max = dayjs().add(lockOptions[maxLockDuration], "days");
-  const roundedDownMax = roundDownToWeekBoundary(max);
-  const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
+  const maxLocked = isNftMaxLocked(nft);
   return (
     <div className={classes.someContainer}>
       <div className={classes.inputsContainer3}>


### PR DESCRIPTION
Would love to introduce a max lock button to save me a few clicks every epoch:

![image](https://github.com/Velocimeter/frontend/assets/126733611/5a50e5f8-d0de-4307-ab37-f869636555ba)

1. the UI will tell you right from the table if the nft is max locked or not
2. if not, we'll have a max lock menu item to max lock the nft, no need to enter `Manage`, select 4 years, and lock.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new function `isNftMaxLocked` and implementing a "Max Lock" feature in the `ssVestsTable` component.

### Detailed summary:
- Added a new function `isNftMaxLocked` in `lockDuration.tsx` to check if an NFT is at its maximum lock duration.
- Implemented a "Max Lock" feature in the `ssVestsTable` component.
- Added a new menu option "Max Lock" for NFTs that are not at their maximum lock duration.
- When "Max Lock" is clicked, the `onMaxLock` function is called to increase the lock duration to the maximum allowed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->