### PR TITLE
add max lock button

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lockDuration.tsx
+++ b/Frontend-v1-Original/components/ssVest/lockDuration.tsx
@@ -39,6 +39,13 @@ function roundDownToWeekBoundary(date: dayjs.Dayjs) {
   return Math.floor(timestamp / WEEK) * WEEK;
 }
 
+export function isNftMaxLocked(nft: VestNFT): boolean {
+  const max = dayjs().add(lockOptions[maxLockDuration], "days");
+  const roundedDownMax = roundDownToWeekBoundary(max);
+  const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
+  return maxLocked; 
+}
+
 export default function LockDuration({
   nft,
   updateLockDuration,
@@ -157,9 +164,7 @@ export default function LockDuration({
     );
   };
 
-  const max = dayjs().add(lockOptions[maxLockDuration], "days");
-  const roundedDownMax = roundDownToWeekBoundary(max);
-  const maxLocked = roundedDownMax === Number(nft.lockEnds) * 1000;
+  const maxLocked = isNftMaxLocked(nft);
   return (
     <div className={classes.someContainer}>
       <div className={classes.inputsContainer3}>

--- a/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
+++ b/Frontend-v1-Original/components/ssVests/ssVestsTable.tsx
@@ -30,6 +30,7 @@ import {
   Merge,
   TrendingUp,
   Send,
+  Lock,
 } from "@mui/icons-material";
 import dayjs from "dayjs";
 import BigNumber from "bignumber.js";
@@ -37,7 +38,8 @@ import Link from "next/link";
 
 import { formatCurrency } from "../../utils/utils";
 import { GovToken, VestNFT, VeToken } from "../../stores/types/types";
-import { useResetVest } from "../ssVest/lib/mutations";
+import { useIncreaseVestDuration, useResetVest } from "../ssVest/lib/mutations";
+import { isNftMaxLocked, lockOptions, maxLockDuration } from "../ssVest/lockDuration";
 
 const headCells = [
   { id: "NFT", numeric: false, disablePadding: false, label: "NFT" },
@@ -348,6 +350,20 @@ function MyTableRow(props: {
     setAnchorEl(null);
   };
 
+  const {
+    mutate: increateVestDuration
+  } = useIncreaseVestDuration();
+
+  const onMaxLock = (nft: VestNFT) => {
+    const now = dayjs();
+    const expiry = dayjs().add(lockOptions[maxLockDuration], 'days')
+    const diff = expiry.diff(now, 'seconds');
+    increateVestDuration({
+      tokenID: nft.id,
+      unlockTime: diff.toString()
+    });
+  }
+
   return (
     <TableRow key={labelId} className="hover:bg-[rgba(104,108,122,0.05)]">
       <TableCell>
@@ -450,7 +466,7 @@ function MyTableRow(props: {
           className="text-xs font-extralight"
           color="textSecondary"
         >
-          Expires {dayjs.unix(+row.lockEnds).fromNow()}
+          {isNftMaxLocked(row) ? ('MAX LOCKED') : `Expires ${dayjs.unix(+row.lockEnds).fromNow()}`}
         </Typography>
       </TableCell>
       <TableCell align="right">
@@ -530,6 +546,15 @@ function MyTableRow(props: {
           <MenuItem disableRipple onClick={() => onView(row)}>
             <TrendingUp className="mr-2" /> Manage
           </MenuItem>
+          {
+            !isNftMaxLocked(row) ? <MenuItem disableRipple onClick={() => {
+              handleClose();
+              onMaxLock(row)
+            }}>
+              <Lock className="mr-2" /> Max Lock
+            </MenuItem> : null
+          }
+          
         </Menu>
       </TableCell>
     </TableRow>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a "Max Lock" option to the lock duration feature in the ssVestsTable component.

### Detailed summary
- Added `isNftMaxLocked` function to check if an NFT is at its maximum lock duration.
- Added `useIncreaseVestDuration` hook to handle increasing the vest duration.
- Added "Max Lock" option to the context menu in the ssVestsTable component.
- Updated the expiration display in the ssVestsTable component to show "MAX LOCKED" if the NFT is at its maximum lock duration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->