### PR TITLE
quote add liq when pair exists but emtpy and invalidate pair by address

### DIFF
--- a/Frontend-v1-Original/components/liquidityManage/LiquidityManage.tsx
+++ b/Frontend-v1-Original/components/liquidityManage/LiquidityManage.tsx
@@ -1022,7 +1022,7 @@ export default function LiquidityManage() {
                       <Typography className="font-bold capitalize">
                         {isAddLiqLoading ? `Depositing` : `Deposit`}
                       </Typography>
-                      {isAddLiqLoading || (
+                      {isAddLiqLoading && (
                         <CircularProgress
                           size={10}
                           className="ml-2 fill-white"

--- a/Frontend-v1-Original/components/liquidityManage/LiquidityManage.tsx
+++ b/Frontend-v1-Original/components/liquidityManage/LiquidityManage.tsx
@@ -436,7 +436,7 @@ export default function LiquidityManage() {
   };
 
   const handleAmount0Input = (input: string) => {
-    if (!pair || !pair.token0 || !pair.token1) {
+    if (!pair || !pair.token0 || !pair.token1 || pair.totalSupply === 0) {
       return setAmount0(input);
     }
 
@@ -490,7 +490,7 @@ export default function LiquidityManage() {
   };
 
   const handleAmount1Input = (input: string) => {
-    if (!pair || !pair.token0 || !pair.token1) {
+    if (!pair || !pair.token0 || !pair.token1 || pair.totalSupply === 0) {
       return setAmount1(input);
     }
 

--- a/Frontend-v1-Original/components/liquidityManage/lib/mutations.ts
+++ b/Frontend-v1-Original/components/liquidityManage/lib/mutations.ts
@@ -31,9 +31,7 @@ import {
 import { getTXUUID } from "../../../utils/utils";
 import { useTransactionStore } from "../../transactionQueue/transactionQueue";
 
-import { getPairByAddress } from "./queries";
-
-const PAIR_BY_ADDRESS = "pairByAddress";
+import { getPairByAddress, KEYS as MANAGE_PAIR_KEYS } from "./queries";
 
 // --- hooks ---
 
@@ -52,7 +50,7 @@ export function useCreatePairStake(onSuccess?: () => void) {
     onSuccess: () => {
       onSuccess?.();
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
     },
   });
 }
@@ -72,7 +70,7 @@ export function useCreatePairDeposit(onSuccess?: () => void) {
     onSuccess: () => {
       onSuccess?.();
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
     },
   });
 }
@@ -91,7 +89,7 @@ export function useAddLiquidity(onSuccess?: () => void) {
     }) => addLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -105,7 +103,7 @@ export function useStakeLiquidity(onSuccess?: () => void) {
       stakeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -126,7 +124,7 @@ export function useAddLiquidityAndStake(onSuccess?: () => void) {
     }) => addLiquidityAndStake(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -144,7 +142,7 @@ export function useRemoveLiquidity(onSuccess?: () => void) {
     }) => removeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -165,7 +163,7 @@ export function useUnstakeAndRemoveLiquidity(onSuccess?: () => void) {
     }) => unstakeAndRemoveLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -179,7 +177,7 @@ export function useUnstakeLiquidity(onSuccess?: () => void) {
       unstakeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
-      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
+      queryClient.invalidateQueries([MANAGE_PAIR_KEYS.PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });

--- a/Frontend-v1-Original/components/liquidityManage/lib/mutations.ts
+++ b/Frontend-v1-Original/components/liquidityManage/lib/mutations.ts
@@ -33,6 +33,8 @@ import { useTransactionStore } from "../../transactionQueue/transactionQueue";
 
 import { getPairByAddress } from "./queries";
 
+const PAIR_BY_ADDRESS = "pairByAddress";
+
 // --- hooks ---
 
 export function useCreatePairStake(onSuccess?: () => void) {
@@ -50,6 +52,7 @@ export function useCreatePairStake(onSuccess?: () => void) {
     onSuccess: () => {
       onSuccess?.();
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
     },
   });
 }
@@ -69,6 +72,7 @@ export function useCreatePairDeposit(onSuccess?: () => void) {
     onSuccess: () => {
       onSuccess?.();
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
     },
   });
 }
@@ -87,6 +91,7 @@ export function useAddLiquidity(onSuccess?: () => void) {
     }) => addLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -100,6 +105,7 @@ export function useStakeLiquidity(onSuccess?: () => void) {
       stakeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -120,6 +126,7 @@ export function useAddLiquidityAndStake(onSuccess?: () => void) {
     }) => addLiquidityAndStake(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -137,6 +144,7 @@ export function useRemoveLiquidity(onSuccess?: () => void) {
     }) => removeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -157,6 +165,7 @@ export function useUnstakeAndRemoveLiquidity(onSuccess?: () => void) {
     }) => unstakeAndRemoveLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });
@@ -170,6 +179,7 @@ export function useUnstakeLiquidity(onSuccess?: () => void) {
       unstakeLiquidity(address, options),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
+      queryClient.invalidateQueries([PAIR_BY_ADDRESS]);
       onSuccess?.();
     },
   });

--- a/Frontend-v1-Original/components/liquidityManage/lib/queries.ts
+++ b/Frontend-v1-Original/components/liquidityManage/lib/queries.ts
@@ -23,7 +23,7 @@ import {
 
 import { useAmounts } from "./useAmounts";
 
-const KEYS = {
+export const KEYS = {
   PAIR_EXISTANCE: "pairExistance",
   PAIR_BY_ADDRESS: "pairByAddress",
   QUOTE_ADD_LIQUIDITY: "quoteAddLiquidity",


### PR DESCRIPTION
canto

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the liquidity management functionality. 

### Detailed summary
- Exported `KEYS` constant in `queries.ts`.
- Added a condition to handle input when `pair.totalSupply` is 0 in `handleAmount0Input` and `handleAmount1Input` functions.
- Updated the condition for rendering the `CircularProgress` component in the `LiquidityManage` component.
- Updated imports and added `MANAGE_PAIR_KEYS` constant in `mutations.ts`.
- Invalidated queries for `PAIR_BY_ADDRESS` in various functions in `mutations.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->