### PR TITLE
reuse PageWrapper (pulse)

### DIFF
--- a/Frontend-v1-Original/pages/options/index.tsx
+++ b/Frontend-v1-Original/pages/options/index.tsx
@@ -1,27 +1,15 @@
 import { Typography, Paper } from "@mui/material";
 
-import { useAccount } from "wagmi";
-
 import { Redeem } from "../../components/options/redeem";
 import { Stake } from "../../components/options/stake";
 import { Reward } from "../../components/options/reward";
 import { Convert } from "../../components/options/convert";
+import { PageWrapper } from "../../components/common/PageWrapper";
 
-function Rewards() {
-  const { address } = useAccount();
-
+function Options() {
   return (
-    <div className="relative my-3 flex h-full w-full flex-col pt-8">
-      {address ? (
-        <div className="flex flex-wrap items-stretch justify-center gap-5">
-          <Redeem />
-          <div className="flex flex-col items-center justify-between gap-1">
-            <Stake />
-            <Reward />
-            <Convert />
-          </div>
-        </div>
-      ) : (
+    <PageWrapper
+      placeholder={
         <Paper className="fixed top-0 flex h-[calc(100%-150px)] w-full flex-col flex-wrap items-center justify-center bg-[rgba(17,23,41,0.2)] p-12 text-center shadow-none max-lg:my-auto max-lg:mt-24 max-lg:mb-0 lg:h-[100vh] lg:w-full">
           <div className="relative z-10">
             <Typography
@@ -38,9 +26,18 @@ function Rewards() {
             </Typography>
           </div>
         </Paper>
-      )}
-    </div>
+      }
+    >
+      <div className="flex flex-wrap items-stretch justify-center gap-5">
+        <Redeem />
+        <div className="flex flex-col items-center justify-between gap-1">
+          <Stake />
+          <Reward />
+          <Convert />
+        </div>
+      </div>
+    </PageWrapper>
   );
 }
 
-export default Rewards;
+export default Options;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the options page in the frontend. 

### Detailed summary
- Removed the `useAccount` import from "wagmi"
- Added a new component `PageWrapper` to wrap the options page content
- Replaced the previous content of the options page with the new `PageWrapper` component
- Updated the function name from `Rewards` to `Options`
- Updated the export statement to export `Options` instead of `Rewards`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->