### PR TITLE
make header more mobile friendly

### DIFF
--- a/Frontend-v1-Original/components/common/PageWrapper.tsx
+++ b/Frontend-v1-Original/components/common/PageWrapper.tsx
@@ -11,7 +11,8 @@ export function PageWrapper(props: Props) {
       {address ? (
         <div>{props.children}</div>
       ) : (
-        <Paper className="fixed top-0 flex h-[calc(100%-150px)] w-full flex-col flex-wrap items-center justify-center bg-appBackground p-12 text-center shadow-none after:absolute after:top-0 after:left-0 after:hidden after:h-full after:w-full after:bg-waves after:bg-cover after:bg-no-repeat max-lg:my-auto max-lg:mt-24 max-lg:mb-0 after:xs:block lg:h-[100vh] lg:w-full">
+        <Paper className="fixed top-0 flex h-full w-full flex-col flex-wrap items-center justify-center bg-appBackground p-12 text-center shadow-none after:absolute after:top-0 after:left-0 after:hidden after:h-full after:w-full after:bg-waves after:bg-cover after:bg-no-repeat max-lg:my-auto max-lg:mb-0 after:xs:block lg:h-[100vh] lg:w-full">
+          <div className="max-lg:mt-24"></div>
           {props.placeholder}
         </Paper>
       )}

--- a/Frontend-v1-Original/components/header/header.tsx
+++ b/Frontend-v1-Original/components/header/header.tsx
@@ -19,8 +19,8 @@ function SiteLogo(props: { className?: string }) {
       className={className}
       src="/images/fvm_logo_blue.png"
       alt="fvm by velocimeter logo"
-      height={38}
-      width={256}
+      height={357}
+      width={1200}
     />
   );
 }
@@ -42,12 +42,12 @@ function Header() {
         }`}
       >
         <Info />
-        <div className="flex min-h-[60px] items-center justify-between rounded-none border-none py-5 px-8 md:max-[1200px]:flex-col">
+        <div className="flex min-h-[60px] items-center justify-between rounded-none border-none px-5">
           <a
             onClick={() => router.push("/home")}
-            className="flex cursor-pointer items-center justify-center gap-2 rounded-[40px] py-1"
+            className="flex flex-shrink-0 cursor-pointer items-center justify-center gap-2 rounded-[40px] py-5"
           >
-            <SiteLogo />
+            <SiteLogo className="h-[50px] w-auto" />
           </a>
           <Navigation />
           <div className="flex justify-end gap-1 md:max-[1200px]:w-full md:max-[1200px]:items-end md:max-[1200px]:px-8 xl:w-[260px]">
@@ -79,7 +79,9 @@ function Header() {
                 </Badge>
               </IconButton>
             )}
-            <ConnectButton />
+            <span className="md:fixed md:right-5 md:bottom-5 xl:static">
+              <ConnectButton />
+            </span>
           </div>
           <TransactionQueue />
         </div>

--- a/Frontend-v1-Original/components/header/info.tsx
+++ b/Frontend-v1-Original/components/header/info.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 
 import { CONTRACTS } from "../../stores/constants/constants";
 
@@ -11,6 +11,11 @@ import {
   useTvl,
 } from "./lib/queries";
 
+interface InfoItem {
+  label: string;
+  value: string | ReactNode;
+}
+
 export default function Info() {
   const { data: tokenPrices } = useTokenPrices();
   const { data: updateDate } = useActivePeriod();
@@ -19,42 +24,46 @@ export default function Info() {
   const { data: circulatingSupply } = useCirculatingSupply();
   const { data: mCap } = useMarketCap();
 
+  const infoItems: InfoItem[] = [
+    {
+      label: "TVL",
+      value: `$${formatFinancialData(tvl ?? 0)}`,
+    },
+    {
+      label: "Total Bribe Value",
+      value: `$${formatFinancialData(tbv ?? 0)}`,
+    },
+    {
+      label: "FLOW Price",
+      value: `$${(
+        tokenPrices?.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase()) ?? 0
+      ).toFixed(3)}`,
+    },
+    {
+      label: "Market Cap",
+      value: `$${formatFinancialData(mCap ?? 0)}`,
+    },
+    {
+      label: "Circulating Supply",
+      value: formatFinancialData(circulatingSupply ?? 0),
+    },
+    {
+      label: "Next Epoch",
+      value: <Timer deadline={updateDate} />,
+    },
+  ];
+
   return (
-    <div className="flex flex-col items-start gap-1 px-6 pt-2 font-sono md:flex-row md:items-center md:gap-3 md:px-4">
-      <div>
-        <span className="font-normal">TVL: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(tvl ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">TBV: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(tbv ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">$FVM price: </span>
-        <span className="tracking-tighter">
-          $
-          {(
-            tokenPrices?.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase()) ?? 0
-          ).toFixed(3)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">MCap: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(mCap ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">Circulating Supply: </span>
-        <span className="tracking-tighter">
-          {formatFinancialData(circulatingSupply ?? 0)}
-        </span>
-      </div>
-      <Timer deadline={updateDate} />
+    <div className="grid gap-1 px-[14px] font-sono text-sm md:flex md:flex-row md:items-stretch md:py-3 lg:gap-x-5">
+      {infoItems.map((item) => (
+        <div
+          key={item.label}
+          className="flex w-full items-center justify-between space-x-3 md:grid md:grid-cols-1 md:grid-rows-2 md:items-start md:space-x-0 lg:flex lg:w-auto lg:items-center lg:justify-start lg:gap-x-1"
+        >
+          <span className="font-normal text-gray-500">{item.label}</span>
+          <span className="tracking-tighter">{item.value}</span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -68,14 +77,11 @@ function Timer({ deadline }: { deadline: number | undefined }) {
   const { days, hours, minutes, seconds } = useTimer(deadline, SECOND);
 
   return (
-    <div>
-      <span className="font-normal">Next Epoch: </span>
-      <span className="tracking-tighter">
-        {days + hours + minutes + seconds <= 0
-          ? "0d_0h_0m"
-          : `${days}d_${hours}h_${minutes}m_${seconds}s`}
-      </span>
-    </div>
+    <>
+      {days + hours + minutes + seconds <= 0
+        ? "0d_0h_0m"
+        : `${days}d_${hours}h_${minutes}m_${seconds}s`}
+    </>
   );
 }
 

--- a/Frontend-v1-Original/components/header/mobileHeader.tsx
+++ b/Frontend-v1-Original/components/header/mobileHeader.tsx
@@ -19,8 +19,8 @@ function SiteLogo(props: { className?: string }) {
       className={className}
       src="/images/only_fvm_blue.png"
       alt="fvm by velocimeter logo"
-      height={38}
-      width={256}
+      height={357}
+      width={1200}
     />
   );
 }
@@ -44,7 +44,7 @@ function Header() {
             onClick={() => router.push("/home")}
             className="flex cursor-pointer items-center justify-center gap-2 rounded-[40px] py-5"
           >
-            <SiteLogo />
+            <SiteLogo className="h-[38px] w-auto" />
           </a>
           <button onClick={() => setOpen((prev) => !prev)}>
             {open ? <Close /> : <MenuIcon />}
@@ -56,13 +56,13 @@ function Header() {
           onClose={() => setOpen(false)}
           className="relative md:hidden"
           PaperProps={{
-            className: "flex flex-col items-start py-5 px-6 space-y-2",
+            className: "flex flex-col items-start py-5 px-6",
           }}
           data-rk
         >
           <button
             onClick={() => setOpen(false)}
-            className="absolute top-0 right-6 flex h-[78px] cursor-pointer items-center"
+            className="absolute top-5 right-5 flex h-[40px] cursor-pointer items-center"
           >
             <Close />
           </button>
@@ -90,7 +90,9 @@ function Header() {
               </IconButton>
             )}
           </div>
+          <div className="h-10"></div>
           <Navigation />
+          <div className="h-10"></div>
           <Info />
           <TransactionQueue />
         </Drawer>

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -80,8 +80,10 @@ function Navigation() {
       <Link
         href={"/" + link}
         className={`cursor-pointer select-none appearance-none rounded-lg px-[14px] py-2 text-sm capitalize no-underline outline-0 transition-colors lg:text-base ${
-          active === link ? "bg-cyan text-black hover:text-white" : ""
-        } hover:bg-[hsla(0,0%,100%,.04)]`}
+          active === link
+            ? "bg-cyan text-black"
+            : "hover:bg-[hsla(0,0%,100%,.04)]"
+        }`}
       >
         {title}
       </Link>

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from "next/link";

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, ReactNode } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from "next/link";
 import { Menu, MenuItem } from "@mui/material/";
+import { OpenInNew } from "@mui/icons-material";
 
 function Navigation() {
   const router = useRouter();
@@ -62,7 +63,6 @@ function Navigation() {
   const renderNavs = () => {
     return (
       <>
-        {renderSubNav("Claim", "claim")}
         {renderSubNav("Swap", "swap")}
         {renderSubNav("Liquidity", "liquidity")}
         {renderSubNav("Vest", "vest")}
@@ -70,6 +70,7 @@ function Navigation() {
         {renderSubNav("Rewards", "rewards")}
         {renderSubNav("Options", "options")}
         {renderSubNav("Bribe", "bribe")}
+        {renderSubNav("Claim", "claim")}
         {renderMoreTab()}
       </>
     );
@@ -78,16 +79,17 @@ function Navigation() {
     return (
       <Link
         href={"/" + link}
-        className={`relative m-0 cursor-pointer select-none appearance-none rounded-lg border bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondary no-underline outline-0 ${
-          active === link ? "border-primary text-white" : "border-transparent"
-        } inline-flex items-center justify-center hover:bg-[hsla(0,0%,100%,.04)]`}
+        className={`cursor-pointer select-none appearance-none rounded-lg px-[14px] py-2 text-sm capitalize no-underline outline-0 transition-colors lg:text-base ${
+          active === link ? "bg-cyan text-black hover:text-white" : ""
+        } hover:bg-[hsla(0,0%,100%,.04)]`}
       >
-        <div className="m-0 pl-0 text-center text-xs xs:text-base">{title}</div>
+        {title}
       </Link>
     );
   };
 
   const renderMoreTab = () => {
+    // TODO reckon we should probably move those links to a footer section
     return (
       <>
         <button
@@ -96,9 +98,9 @@ function Navigation() {
           aria-haspopup="true"
           aria-expanded={open ? "true" : undefined}
           onClick={handleClick}
-          className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondary no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
+          className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-start rounded-lg border border-transparent bg-transparent px-[14px] pt-2 pb-[10px] text-sm capitalize text-white no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)] lg:text-base"
         >
-          <div className="m-0 pl-0 text-center text-xs xs:text-base">More</div>
+          More
         </button>
         <Menu
           id="basic-menu"
@@ -118,50 +120,66 @@ function Navigation() {
             },
           }}
         >
-          <MenuItem
-            className="relative m-0 inline-flex w-full cursor-pointer select-none appearance-none items-center justify-center gap-1 rounded-lg border border-transparent bg-transparent p-1 text-sm font-medium text-secondary no-underline outline-0 hover:bg-secondary hover:text-black"
-            onClick={handleScantoClick}
-          >
-            <Image
-              src="/images/sCANTO.png"
-              width={40}
-              height={40}
-              alt="sCANTO Token Icon"
-            />
-            <div className="m-0 pl-0 text-center text-xs xs:text-base">
-              sCANTO
-            </div>
-          </MenuItem>
-          <MenuItem
-            className="relative m-0 inline-flex w-full cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondary no-underline outline-0 hover:bg-secondary hover:text-black"
-            onClick={handleDocsClick}
-          >
-            <div className="m-0 pl-0 text-center text-xs xs:text-base">
-              Docs
-            </div>
-          </MenuItem>
-          <MenuItem
-            className="relative m-0 inline-flex w-full cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondary no-underline outline-0 hover:bg-secondary hover:text-black"
-            onClick={handleGeckoClick}
-          >
-            <div className="m-0 pl-0 text-center text-xs xs:text-base">
-              Coingecko
-            </div>
-          </MenuItem>
+          {[
+            {
+              onClickHandler: handleScantoClick,
+              children: (
+                <>
+                  <Image
+                    src="/images/sCANTO.png"
+                    width={156}
+                    height={156}
+                    className="h-[30px] w-[30px]"
+                    alt="sCANTO Token Icon"
+                  />
+                  sCANTO <OpenInNew className="w-4" />
+                </>
+              ),
+            },
+            {
+              onClickHandler: handleDocsClick,
+              children: (
+                <>
+                  Docs <OpenInNew className="w-4" />
+                </>
+              ),
+            },
+            {
+              onClickHandler: handleGeckoClick,
+              children: (
+                <>
+                  Coingecko <OpenInNew className="w-4" />
+                </>
+              ),
+            },
+          ].map(
+            (
+              item: {
+                onClickHandler: () => void;
+                children: ReactNode;
+              },
+              index
+            ) => {
+              return (
+                <MenuItem
+                  key={index}
+                  className="relative m-0 inline-flex min-h-[30px] w-full cursor-pointer select-none appearance-none items-center justify-start gap-1 rounded-lg border border-transparent bg-transparent px-[14px] text-sm no-underline outline-0 hover:bg-secondary hover:text-black"
+                  onClick={item.onClickHandler}
+                >
+                  {item.children}
+                </MenuItem>
+              );
+            }
+          )}
         </Menu>
       </>
     );
   };
 
   return (
-    <>
-      <div className="flex items-center rounded-2xl border-0 bg-transparent p-2 text-center shadow-[0_0_0.2em] shadow-primary max-md:hidden">
-        {renderNavs()}
-      </div>
-      <div className="flex flex-col items-start py-2 text-center md:hidden">
-        {renderNavs()}
-      </div>
-    </>
+    <div className="grid w-full grid-cols-1 gap-y-1 md:flex md:w-auto md:items-center md:gap-x-1 md:rounded-2xl md:border-0 md:bg-transparent md:p-2 md:text-center">
+      {renderNavs()}
+    </div>
   );
 }
 


### PR DESCRIPTION
This pull request aims to improve the UI making it more mobile friendly, also refactored some code keeping they DRY.

Quite some drastic UI changes, but much cleaner IMO, and of course, more velocimeter brand color used :)

Let me know what you think.

## Before

<img width="632" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/03c62faf-4137-4e19-b9fa-78d6bb9431ad">

## After

<img width="639" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/8565fd33-b288-4ba6-9cea-f4ab33e85172">


## Before

<img width="977" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/f87f59c4-773c-43ae-abc6-1879627c01e4">

## After

<img width="987" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/f5a47516-2a20-47eb-b91b-0267eead6f3f">

## Before

<img width="1457" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/537e6826-616e-4161-b68b-98fb4c5c3fd7">

## After

<img width="1454" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/2f44565b-c67d-4bdf-bf28-686e71c5bd99">

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the `PageWrapper` component to adjust the height of the `Paper` element
- Updated the `header.tsx` and `mobileHeader.tsx` components to modify the logo size and positioning
- Added a new `Info` component with various information items
- Updated the `navigation.tsx` component to include new navigation items and styling changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->