### PR TITLE
fix unit tests for pulse

### DIFF
--- a/Frontend-v1-Original/components/ssVest/TransferNFT.tsx
+++ b/Frontend-v1-Original/components/ssVest/TransferNFT.tsx
@@ -11,45 +11,13 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useReducer } from "react";
-import { type Address, isAddress } from "viem";
+import { type Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { useTransferVest } from "./lib/mutations";
 import { useNftById } from "./lib/queries";
 
-export function reducer(
-  state: {
-    address: string;
-    helperText: string;
-    error: boolean;
-    currentAddress?: Address;
-  },
-  action: { type: string; payload: string }
-) {
-  switch (action.type) {
-    case "address":
-      let helperText = "";
-      let error = false;
-      const { payload } = action;
-      if (payload === "") {
-        helperText = "";
-        error = false;
-      } else {
-        if (!isAddress(payload)) {
-          helperText = "Invalid Address";
-          error = true;
-        } else if (
-          payload.toLowerCase() === state.currentAddress?.toLowerCase()
-        ) {
-          helperText = "Cannot transfer to self";
-          error = true;
-        }
-      }
-      return { ...state, address: action.payload, helperText, error };
-    default:
-      return state;
-  }
-}
+import { transferNftReducer as reducer } from "./reducers";
 
 export function TransferNFT() {
   const router = useRouter();

--- a/Frontend-v1-Original/components/ssVest/reducers.test.tsx
+++ b/Frontend-v1-Original/components/ssVest/reducers.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { reducer } from "./TransferNFT";
+import { transferNftReducer as reducer } from "./reducers";
 
 const blackhole = "0x0000000000000000000000000000000000000000";
 

--- a/Frontend-v1-Original/components/ssVest/reducers.tsx
+++ b/Frontend-v1-Original/components/ssVest/reducers.tsx
@@ -1,0 +1,34 @@
+import { type Address, isAddress } from "viem";
+export function transferNftReducer(
+  state: {
+    address: string;
+    helperText: string;
+    error: boolean;
+    currentAddress?: Address;
+  },
+  action: { type: string; payload: string }
+) {
+  switch (action.type) {
+    case "address":
+      let helperText = "";
+      let error = false;
+      const { payload } = action;
+      if (payload === "") {
+        helperText = "";
+        error = false;
+      } else {
+        if (!isAddress(payload)) {
+          helperText = "Invalid Address";
+          error = true;
+        } else if (
+          payload.toLowerCase() === state.currentAddress?.toLowerCase()
+        ) {
+          helperText = "Cannot transfer to self";
+          error = true;
+        }
+      }
+      return { ...state, address: action.payload, helperText, error };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `reducer` function in the `TransferNFT` component. 

### Detailed summary
- Renamed the `reducer` function to `transferNftReducer` in both the test file and the component file.
- Moved the `reducer` function to a separate file called `reducers.tsx`.
- Updated the import statement for the `reducer` function in the `TransferNFT` component.
- Added type annotations for the `state` and `action` parameters in the `transferNftReducer` function.
- Updated the logic inside the `transferNftReducer` function to handle the `address` action type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->