### PR TITLE
add separate page for vest/create

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -16,9 +16,10 @@ import BigNumber from "bignumber.js";
 import dayjs from "dayjs";
 import { ArrowBack } from "@mui/icons-material";
 
+import { useGovToken, useVeToken } from "../../lib/global/queries";
 import { formatCurrency } from "../../utils/utils";
 
-import { GovToken, VeToken, VestNFT } from "../../stores/types/types";
+import { GovToken, VestNFT } from "../../stores/types/types";
 
 import VestingInfo from "./vestingInfo";
 import classes from "./ssVest.module.css";
@@ -26,13 +27,7 @@ import classes from "./ssVest.module.css";
 import { type LockOption, lockOptions, defaultLockDuration, maxLockDuration } from "./lockDuration";
 import { useCreateVest } from "./lib/mutations";
 
-export default function Lock({
-  govToken,
-  veToken,
-}: {
-  govToken: GovToken | undefined;
-  veToken: VeToken | undefined;
-}) {
+export default function Lock() {
   const inputEl = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
 
@@ -43,6 +38,8 @@ export default function Lock({
     dayjs().add(lockOptions[defaultLockDuration], "days").format("YYYY-MM-DD")
   );
   const [selectedDateError] = useState(false);
+  const { data: govToken } = useGovToken();
+  const { data: veToken } = useVeToken();
 
   const { mutate: createVest, isLoading: lockLoading } = useCreateVest(() => {
     router.push("/vest");
@@ -282,7 +279,7 @@ export default function Lock({
   };
 
   return (
-    <>
+    <div className={classes.vestContainer}>
       <Paper elevation={0} className={classes.container3}>
         <div className={classes.titleSection}>
           <Tooltip title="Back to Vest" placement="top">
@@ -343,6 +340,6 @@ export default function Lock({
       </Paper>
       <br />
       <br />
-    </>
+    </div>
   );
 }

--- a/Frontend-v1-Original/components/ssVest/ssVest.tsx
+++ b/Frontend-v1-Original/components/ssVest/ssVest.tsx
@@ -6,7 +6,6 @@ import { useGovToken, useVeToken } from "../../lib/global/queries";
 
 import ExistingLock from "./existingLock";
 import Unlock from "./unlock";
-import Lock from "./lock";
 import classes from "./ssVest.module.css";
 import { useNftById } from "./lib/queries";
 
@@ -20,17 +19,12 @@ export default function Vest() {
 
   return (
     <div className={classes.vestContainer}>
-      {router.query.id === "create" && (
-        <Lock govToken={govToken} veToken={veToken} />
-      )}
-      {router.query.id !== "create" &&
-        nft &&
+      {nft &&
         BigNumber(nft.lockEnds).gte(dayjs().unix()) &&
         BigNumber(nft.lockEnds).gt(0) && (
           <ExistingLock nft={nft} govToken={govToken} veToken={veToken} />
         )}
-      {router.query.id !== "create" &&
-        nft &&
+      {nft &&
         BigNumber(nft.lockEnds).lt(dayjs().unix()) &&
         BigNumber(nft.lockEnds).gt(0) && (
           <Unlock nft={nft} govToken={govToken} veToken={veToken} />

--- a/Frontend-v1-Original/pages/vest/create/index.tsx
+++ b/Frontend-v1-Original/pages/vest/create/index.tsx
@@ -1,0 +1,33 @@
+import { Typography } from "@mui/material";
+
+import Lock from "../../../components/ssVest/lock";
+import { PageWrapper } from "../../../components/common/PageWrapper";
+
+function Vest() {
+  return (
+    <PageWrapper
+      placeholder={
+        <>
+          <Typography
+            className="text-center font-['Monument'] text-2xl font-thin text-white sm:text-3xl"
+            variant="h1"
+          >
+            Vest
+          </Typography>
+          <Typography
+            className="my-7 mx-auto max-w-3xl text-center text-base text-secondary sm:text-lg"
+            variant="body2"
+          >
+            Lock your FVM to earn rewards and governance rights. Each locked
+            position is created and represented as an NFT, meaning you can hold
+            multiple locked positions.
+          </Typography>
+        </>
+      }
+    >
+      <Lock />
+    </PageWrapper>
+  );
+}
+
+export default Vest;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `Typography` component and text content to the `Vest` page.
- Imported and rendered the `Lock` component within the `Vest` page.
- Removed the import and rendering of the `Lock` component in the `ssVest` component.
- Updated the `Lock` component to use the `useGovToken` and `useVeToken` hooks.
- Removed the `govToken` and `veToken` props from the `Lock` component.
- Updated the HTML structure and styling of the `Lock` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->