### PR TITLE
fix sticky

### DIFF
--- a/Frontend-v1-Original/components/header/header.tsx
+++ b/Frontend-v1-Original/components/header/header.tsx
@@ -35,7 +35,7 @@ function Header() {
   return (
     <>
       <div
-        className={`grid w-full grid-flow-row border-primary border-opacity-50 transition-all duration-200 ${
+        className={`grid w-full grid-flow-row border-cyan/50 border-opacity-50 transition-all duration-200 ${
           scrollPosition > 0
             ? "border-b-[0.25px] bg-[rgba(0,0,0,0.973)] opacity-90 backdrop-blur-2xl"
             : "border-b-0 border-none"

--- a/Frontend-v1-Original/components/layout/layout.tsx
+++ b/Frontend-v1-Original/components/layout/layout.tsx
@@ -18,7 +18,7 @@ export default function Layout({
   const { switchNetwork } = useSwitchNetwork({ chainId: fantom.id });
 
   return (
-    <div className="relative flex h-full min-h-screen w-full max-w-[100vw] flex-col overflow-x-hidden md:overflow-x-auto lg:flex-row">
+    <div className="relative flex h-full min-h-screen w-full max-w-[100vw] flex-col lg:flex-row">
       <Head>
         <link rel="icon" href="/images/logo-icon.png" />
         <meta


### PR DESCRIPTION
The sticky is broken due to the `overflow`. Removing them would fix the problem.

Personally I would rather removing `sticky` at all, as we don't have a long page to scroll, user can scroll back to navbar easily, and sticky element just take up quite a lot of space in small screens like laptop:

<img width="1217" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/4ec01381-5bab-4ba7-b8e0-0a8fc373e7d1">
