### PR TITLE
Bugfix/fix z index

### DIFF
--- a/Frontend-v1-Original/components/header/info.tsx
+++ b/Frontend-v1-Original/components/header/info.tsx
@@ -34,7 +34,7 @@ export default function Info() {
       value: `$${formatFinancialData(tbv ?? 0)}`,
     },
     {
-      label: "FLOW Price",
+      label: "FVM Price",
       value: `$${(
         tokenPrices?.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase()) ?? 0
       ).toFixed(3)}`,

--- a/Frontend-v1-Original/components/layout/layout.tsx
+++ b/Frontend-v1-Original/components/layout/layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({
             <div className="block md:hidden">
               <MobileHeader />
             </div>
-            <div className="hidden md:block">
+            <div className="z-10 hidden md:block">
               <Header />
             </div>
           </>


### PR DESCRIPTION
Lmao, rekted.

<img width="1509" alt="image" src="https://github.com/Velocimeter/frontend/assets/126733611/6b3d3387-a304-4c9a-8f71-da31ede67330">


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a `z-10` class to the `div` element in `layout.tsx` to set its z-index to 10.
- Updated the label from "FLOW Price" to "FVM Price" in `info.tsx` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->