### PR TITLE
add e2e test

### DIFF
--- a/Frontend-v1-Original/.github/workflows/playwright.yml
+++ b/Frontend-v1-Original/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: yarn
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/Frontend-v1-Original/.gitignore
+++ b/Frontend-v1-Original/.gitignore
@@ -29,3 +29,6 @@ tsconfig.tsbuildinfo
 .env.*
 
 lib/wagmiGen.ts
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/Frontend-v1-Original/e2e/navbar-clickable.test.ts
+++ b/Frontend-v1-Original/e2e/navbar-clickable.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+const swap = "http://localhost:3000/swap";
+
+// in case we have regression when refactor, like navbar gets hidden due to negative z-index
+test("Liquidity link should be clickable", async ({ page }) => {
+  await page.goto(swap);
+
+  // Click the Liquidity link.
+  await page.getByRole("link", { name: "Liquidity" }).click();
+
+  // Expects the URL to contain liquidity.
+  await expect(page).toHaveURL(/.*liquidity/);
+});

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -11,7 +11,8 @@
     "lint": "next lint",
     "tsc": "tsc --noEmit",
     "prepare": "cd .. && husky install Frontend-v1-Original/.husky",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "PORT=3000 playwright test"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
@@ -44,6 +45,7 @@
     "wagmi": "^1.3.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.35.1",
     "@tanstack/eslint-plugin-query": "^4.29.4",
     "@types/cors": "^2.8.13",
     "@types/node": "^18.16.1",

--- a/Frontend-v1-Original/playwright.config.ts
+++ b/Frontend-v1-Original/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run start",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/Frontend-v1-Original/yarn.lock
+++ b/Frontend-v1-Original/yarn.lock
@@ -1225,6 +1225,16 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@playwright/test@^1.35.1":
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
+  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.35.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 "@popperjs/core@^2.11.6":
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
@@ -4408,7 +4418,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -6015,6 +6025,11 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.35.1:
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
+  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
 
 pngjs@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
The problem of manual testing is we don't really have the bandwidth to test all functions or UI thoroughly, and introducing new features or refactoring would likely cause regressions like https://github.com/Velocimeter/frontend/pull/206.

E2e test wouldn't be a silver bullet, but it can definitely save us sometimes, like running into the same regression again in near future lol.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding end-to-end tests using Playwright for the Frontend-v1-Original project.

### Detailed summary
- Added `@playwright/test` as a dev dependency.
- Created `e2e/navbar-clickable.test.ts` to test the clickability of the Liquidity link.
- Added a Playwright test workflow in `.github/workflows/playwright.yml`.
- Updated `package.json` to include a new script `test:e2e` for running Playwright tests.
- Updated `yarn.lock` to include `@playwright/test@^1.35.1`.
- Added `playwright.config.ts` to configure Playwright tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->