### PR TITLE
update balance after rewards claimed

### DIFF
--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -27,7 +27,7 @@ export function Reward() {
     return earnedRewards?.map((reward) => reward.address);
   }, [earnedRewards]);
 
-  const { underlyingTokenSymbol } = useTokenData();
+  const { underlyingTokenSymbol, refetchBalances } = useTokenData();
 
   const { data: gaugeAddress } = useOptionTokenGauge();
   const { config: getRewardConfig } = usePrepareMaxxingGaugeGetReward({
@@ -46,6 +46,7 @@ export function Reward() {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.BASE_ASSET_INFO]);
       refetchEarnedReward();
+      refetchBalances();
     },
   });
 


### PR DESCRIPTION
Balances of `usdc` and `oFlow` are not updated after rewards claimed.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `refetchBalances` to the `useTokenData` hook
- Added `refetchBalances()` to the `onSuccess` callback in the `Reward` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->