### PR TITLE
FIX/To distribute usd value 

### DIFF
--- a/Frontend-v1-Original/components/options/stake.tsx
+++ b/Frontend-v1-Original/components/options/stake.tsx
@@ -54,6 +54,7 @@ export function Stake() {
     stakedLockEnd,
     totalStakedValue,
     paymentTokenBalanceToDistribute,
+    paymentTokenToDistributeValue,
   } = useStakeData();
 
   const { data: tokenAprs } = useGaugeApr();
@@ -247,7 +248,11 @@ export function Stake() {
         </div>
         <div className="flex items-center justify-between">
           <div>{paymentTokenSymbol} reward</div>
-          <div>${formatCurrency(paymentTokenBalanceToDistribute ?? 0)}</div>
+          <div>
+            {paymentTokenToDistributeValue === undefined
+              ? formatCurrency(paymentTokenBalanceToDistribute ?? 0)
+              : `$${formatCurrency(paymentTokenToDistributeValue)}`}
+          </div>
         </div>
         <div className="flex items-center justify-between">
           <div>Staked without lock</div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The PR focuses on updating the `Stake` component to display the `paymentTokenToDistributeValue` instead of `paymentTokenBalanceToDistribute`.
- It introduces a new function `usePaymentTokenToDistributeValue` to calculate the value of the payment token to be distributed.
- It adds a new helper function `getPaymentTokenToDistributeValue` to calculate the value of the payment token to be distributed based on the token prices.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->