### PR TITLE
fix max lock error

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -105,7 +105,15 @@ export default function Lock() {
       const now = dayjs();
       const expiry = dayjs(selectedDate).add(1, "days");
       const secondsToExpire = expiry.diff(now, "seconds");
-      createVest({ amount, unlockTime: secondsToExpire.toString() });
+      const maxLockDurationInSeconds =
+        lockOptions[maxLockDuration] * 24 * 60 * 60;
+      createVest({
+        amount,
+        unlockTime: (secondsToExpire > maxLockDurationInSeconds
+          ? maxLockDurationInSeconds
+          : secondsToExpire
+        ).toString(),
+      });
     }
   };
 


### PR DESCRIPTION
Closes https://github.com/Velocimeter/frontend/issues/223

Not sure why the `expiry` would add another day here, anyway, we'll compare the result with the max seconds we can use to decide the unlockTime.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new variable `maxLockDurationInSeconds`
- Modified the `createVest` function to consider the `maxLockDurationInSeconds` when setting the `unlockTime` property.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->