### PR TITLE
Improve dynamic displaying of apr and tokens on options page

### DIFF
--- a/Frontend-v1-Original/components/options/lib/useIsEmittingOptions.ts
+++ b/Frontend-v1-Original/components/options/lib/useIsEmittingOptions.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { useContractRead } from "wagmi";
+
+import {
+  useOptionTokenGauge,
+  useOptionTokenHasRole,
+} from "../../../lib/wagmiGen";
+import {
+  CONTRACTS,
+  MINTER_ROLE,
+  ZERO_ADDRESS,
+} from "../../../stores/constants";
+
+export function useIsEmittingOptions() {
+  const { data: gaugeAddress } = useOptionTokenGauge();
+  const { data: hasMinterRole } = useOptionTokenHasRole({
+    args: [MINTER_ROLE, gaugeAddress!],
+    enabled: !!gaugeAddress,
+  });
+  const { data: oFlowOnGauge } = useContractRead({
+    address: gaugeAddress,
+    abi: CONTRACTS.GAUGE_ABI,
+    functionName: "oFlow",
+  });
+
+  return useQuery({
+    queryKey: ["isEmittingOptions", hasMinterRole, oFlowOnGauge],
+    queryFn: () => {
+      return !!hasMinterRole && oFlowOnGauge !== ZERO_ADDRESS;
+    },
+    enabled:
+      hasMinterRole !== undefined &&
+      oFlowOnGauge !== undefined &&
+      !!gaugeAddress,
+  });
+}

--- a/Frontend-v1-Original/components/options/lib/useIsEmittingOptions.ts
+++ b/Frontend-v1-Original/components/options/lib/useIsEmittingOptions.ts
@@ -8,6 +8,7 @@ import {
 import {
   CONTRACTS,
   MINTER_ROLE,
+  QUERY_KEYS,
   ZERO_ADDRESS,
 } from "../../../stores/constants";
 
@@ -24,7 +25,7 @@ export function useIsEmittingOptions() {
   });
 
   return useQuery({
-    queryKey: ["isEmittingOptions", hasMinterRole, oFlowOnGauge],
+    queryKey: [QUERY_KEYS.IS_EMITTING_OPTIONS, hasMinterRole, oFlowOnGauge],
     queryFn: () => {
       return !!hasMinterRole && oFlowOnGauge !== ZERO_ADDRESS;
     },

--- a/Frontend-v1-Original/components/options/reward.tsx
+++ b/Frontend-v1-Original/components/options/reward.tsx
@@ -27,7 +27,7 @@ export function Reward() {
     return earnedRewards?.map((reward) => reward.address);
   }, [earnedRewards]);
 
-  const { underlyingTokenSymbol, refetchBalances } = useTokenData();
+  const { refetchBalances } = useTokenData();
 
   const { data: gaugeAddress } = useOptionTokenGauge();
   const { config: getRewardConfig } = usePrepareMaxxingGaugeGetReward({
@@ -80,10 +80,7 @@ export function Reward() {
               className="flex items-center justify-between space-y-2"
               key={earnedReward.address}
             >
-              {formatCurrency(earnedReward.earnedAmount)}{" "}
-              {earnedReward.symbol === underlyingTokenSymbol
-                ? `o${underlyingTokenSymbol}`
-                : earnedReward.symbol}
+              {formatCurrency(earnedReward.earnedAmount)} {earnedReward.symbol}
             </div>
           ))}
         </div>

--- a/Frontend-v1-Original/components/ssRewards/lib/queries.ts
+++ b/Frontend-v1-Original/components/ssRewards/lib/queries.ts
@@ -11,6 +11,7 @@ import {
   PRO_OPTIONS,
   QUERY_KEYS,
   ZERO_ADDRESS,
+  MINTER_ROLE,
 } from "../../../stores/constants/constants";
 import {
   hasGauge,
@@ -29,9 +30,6 @@ import {
   useVestNfts,
   getInitBaseAssets,
 } from "../../../lib/global/queries";
-
-const MINTER_ROLE =
-  "0xf0887ba65ee2024ea881d91b74c2450ef19e1557f03bed3ea9f16b037cbe2dc9";
 
 export const getRewardBalances = async (
   address: Address | undefined,

--- a/Frontend-v1-Original/stores/constants/constants.ts
+++ b/Frontend-v1-Original/stores/constants/constants.ts
@@ -47,3 +47,6 @@ export const W_NATIVE_ABI = config[fantom.id].wNativeABI;
 
 export const PAIR_DECIMALS = 18;
 export const QUERY_KEYS = queryKeys;
+
+export const MINTER_ROLE =
+  "0xf0887ba65ee2024ea881d91b74c2450ef19e1557f03bed3ea9f16b037cbe2dc9";

--- a/Frontend-v1-Original/stores/constants/queryKeys.ts
+++ b/Frontend-v1-Original/stores/constants/queryKeys.ts
@@ -34,3 +34,6 @@ export const PAIRS_WITH_GAUGES_AND_VOTES = "pairsWithGaugesAndVotes";
 
 // swap
 export const QUOTE_SWAP = "quoteSwap";
+
+// options
+export const IS_EMITTING_OPTIONS = "isEmittingOptions";


### PR DESCRIPTION
dynamically display apr, token symbol and token logo for protocol government token based on if it's emitted as options or not

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- Added a new constant `IS_EMITTING_OPTIONS` to `queryKeys.ts`.
- Added `MINTER_ROLE` constant to `constants.ts`.
- Updated imports and removed unused variables in `queries.ts`.
- Updated imports and removed unused variables in `reward.tsx`.
- Added `useIsEmittingOptions` function to `useIsEmittingOptions.ts`.
- Updated imports and added `useIsEmittingOptions` to `useGaugeRewards.ts`.
- Updated imports and added `useIsEmittingOptions` to `useGaugeApr.ts`.
- Updated `getGaugeRewardTokens` function in `useGaugeRewards.ts`.
- Updated `getGaugeApr` function in `useGaugeApr.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->