### PR TITLE
fix max lock error for canto-v2

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -97,7 +97,15 @@ export default function Lock() {
       const now = dayjs();
       const expiry = dayjs(selectedDate).add(1, "days");
       const secondsToExpire = expiry.diff(now, "seconds");
-      createVest({ amount, unlockTime: secondsToExpire.toString() });
+      const maxLockDurationInSeconds =
+        lockOptions[maxLockDuration] * 24 * 60 * 60;
+      createVest({
+        amount,
+        unlockTime: (secondsToExpire > maxLockDurationInSeconds
+          ? maxLockDurationInSeconds
+          : secondsToExpire
+        ).toString(),
+      });
     }
   };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added a new constant `maxLockDurationInSeconds` to calculate the maximum lock duration in seconds.
- Modified the `createVest` function call to use the `maxLockDurationInSeconds` constant to set the `unlockTime` parameter, taking into account if `secondsToExpire` is greater than `maxLockDurationInSeconds`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->