### PR TITLE
fix max lock error for pulse

### DIFF
--- a/Frontend-v1-Original/components/ssVest/lock.tsx
+++ b/Frontend-v1-Original/components/ssVest/lock.tsx
@@ -105,7 +105,15 @@ export default function Lock() {
       const now = dayjs();
       const expiry = dayjs(selectedDate).add(1, "days");
       const secondsToExpire = expiry.diff(now, "seconds");
-      createVest({ amount, unlockTime: secondsToExpire.toString() });
+      const maxLockDurationInSeconds =
+        lockOptions[maxLockDuration] * 24 * 60 * 60;
+      createVest({
+        amount,
+        unlockTime: (secondsToExpire > maxLockDurationInSeconds
+          ? maxLockDurationInSeconds
+          : secondsToExpire
+        ).toString(),
+      });
     }
   };
 


### PR DESCRIPTION
For `pulse`.

<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The code in `lock.tsx` has been modified to include a check for the maximum lock duration.
- If the calculated `secondsToExpire` is greater than the maximum lock duration, the `unlockTime` is set to the maximum lock duration in seconds.
- Otherwise, the `unlockTime` remains the same as `secondsToExpire`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->