### PR TITLE
[canto-v2] Cherry pick/mobile UI canto v2

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,10 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+
+defaults:
+  run:
+    working-directory: ./Frontend-v1-Original
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: yarn
     - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps
+      run: yarn playwright install --with-deps chromium
     - name: Run Playwright tests
       run: yarn playwright test
     - uses: actions/upload-artifact@v3

--- a/Frontend-v1-Original/.github/workflows/playwright.yml
+++ b/Frontend-v1-Original/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: yarn
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/Frontend-v1-Original/.gitignore
+++ b/Frontend-v1-Original/.gitignore
@@ -29,3 +29,6 @@ tsconfig.tsbuildinfo
 .env.*
 
 lib/wagmiGen.ts
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/Frontend-v1-Original/components/common/PageWrapper.tsx
+++ b/Frontend-v1-Original/components/common/PageWrapper.tsx
@@ -11,7 +11,7 @@ export function PageWrapper(props: Props) {
       {address ? (
         <div>{props.children}</div>
       ) : (
-        <Paper className="fixed top-0 flex h-[calc(100%-150px)] w-full flex-col flex-wrap items-center justify-center bg-[rgba(17,23,41,0.2)] p-12 text-center shadow-none max-lg:my-auto max-lg:mt-24 max-lg:mb-0 lg:h-[100vh] lg:w-full">
+        <Paper className="fixed top-0 flex h-full w-full flex-col flex-wrap items-center justify-center bg-[rgba(17,23,41,0.2)] p-12 text-center shadow-none max-lg:my-auto max-lg:mt-24 max-lg:mb-0 lg:h-[100vh] lg:w-full">
           {props.placeholder}
         </Paper>
       )}

--- a/Frontend-v1-Original/components/header/header.tsx
+++ b/Frontend-v1-Original/components/header/header.tsx
@@ -7,7 +7,6 @@ import Navigation from "../navigation/navigation";
 import TransactionQueue, {
   useTransactionStore,
 } from "../transactionQueue/transactionQueue";
-import useScrollPosition from "../../hooks/useScrollPosition";
 
 import Info from "./info";
 import { ConnectButton } from "./ConnectButton";
@@ -28,19 +27,11 @@ function SiteLogo(props: { className?: string }) {
 function Header() {
   const router = useRouter();
 
-  const scrollPosition = useScrollPosition();
-
   const { openQueue, transactions } = useTransactionStore();
 
   return (
     <>
-      <div
-        className={`grid w-full grid-flow-row border-cantoGreen border-opacity-50 transition-all duration-200 ${
-          scrollPosition > 0
-            ? "border-b-[0.25px] bg-[rgba(0,0,0,0.973)] opacity-90 backdrop-blur-2xl"
-            : "border-b-0 border-none"
-        }`}
-      >
+      <div className="grid w-full grid-flow-row">
         <Info />
         <div className="flex min-h-[60px] items-center justify-between rounded-none border-none px-5">
           <a

--- a/Frontend-v1-Original/components/header/header.tsx
+++ b/Frontend-v1-Original/components/header/header.tsx
@@ -19,8 +19,8 @@ function SiteLogo(props: { className?: string }) {
       className={className}
       src="/images/vcm_logo.png"
       alt="velocimeter logo"
-      height={38}
-      width={256}
+      height={682}
+      width={4643}
     />
   );
 }
@@ -42,12 +42,12 @@ function Header() {
         }`}
       >
         <Info />
-        <div className="flex min-h-[60px] items-center justify-between rounded-none border-none py-5 px-8 md:max-[1200px]:flex-col">
+        <div className="flex min-h-[60px] items-center justify-between rounded-none border-none px-5">
           <a
             onClick={() => router.push("/home")}
-            className="flex cursor-pointer items-center justify-center gap-2 rounded-[40px] py-1"
+            className="flex flex-shrink-0 cursor-pointer items-center justify-center gap-2 rounded-[40px] py-5"
           >
-            <SiteLogo />
+            <SiteLogo className="h-[38px] w-auto" />
           </a>
           <Navigation />
           <div className="flex justify-end gap-1 md:max-[1200px]:w-full md:max-[1200px]:items-end md:max-[1200px]:px-8 xl:w-[260px]">
@@ -79,7 +79,9 @@ function Header() {
                 </Badge>
               </IconButton>
             )}
-            <ConnectButton />
+            <span className="md:fixed md:right-5 md:bottom-5 xl:static">
+              <ConnectButton />
+            </span>
           </div>
           <TransactionQueue />
         </div>

--- a/Frontend-v1-Original/components/header/info.tsx
+++ b/Frontend-v1-Original/components/header/info.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 
 import { CONTRACTS } from "../../stores/constants/constants";
 
@@ -11,6 +11,11 @@ import {
   useTvl,
 } from "./lib/queries";
 
+interface InfoItem {
+  label: string;
+  value: string | ReactNode;
+}
+
 export default function Info() {
   const { data: tokenPrices } = useTokenPrices();
   const { data: updateDate } = useActivePeriod();
@@ -19,42 +24,46 @@ export default function Info() {
   const { data: circulatingSupply } = useCirculatingSupply();
   const { data: mCap } = useMarketCap();
 
+  const infoItems: InfoItem[] = [
+    {
+      label: "TVL",
+      value: `$${formatFinancialData(tvl ?? 0)}`,
+    },
+    {
+      label: "Total Bribe Value",
+      value: `$${formatFinancialData(tbv ?? 0)}`,
+    },
+    {
+      label: "FLOW Price",
+      value: `$${(
+        tokenPrices?.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase()) ?? 0
+      ).toFixed(3)}`,
+    },
+    {
+      label: "Market Cap",
+      value: `$${formatFinancialData(mCap ?? 0)}`,
+    },
+    {
+      label: "Circulating Supply",
+      value: formatFinancialData(circulatingSupply ?? 0),
+    },
+    {
+      label: "Next Epoch",
+      value: <Timer deadline={updateDate} />,
+    },
+  ];
+
   return (
-    <div className="flex flex-col items-start gap-1 px-6 pt-2 font-sono md:flex-row md:items-center md:gap-3 md:px-4">
-      <div>
-        <span className="font-normal">TVL: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(tvl ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">TBV: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(tbv ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">$FLOW price: </span>
-        <span className="tracking-tighter">
-          $
-          {(
-            tokenPrices?.get(CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase()) ?? 0
-          ).toFixed(3)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">MCap: </span>
-        <span className="tracking-tighter">
-          ${formatFinancialData(mCap ?? 0)}
-        </span>
-      </div>
-      <div>
-        <span className="font-normal">Circulating Supply: </span>
-        <span className="tracking-tighter">
-          {formatFinancialData(circulatingSupply ?? 0)}
-        </span>
-      </div>
-      <Timer deadline={updateDate} />
+    <div className="grid gap-1 px-[14px] font-sono text-sm md:flex md:flex-row md:items-stretch md:py-3 lg:gap-x-5">
+      {infoItems.map((item) => (
+        <div
+          key={item.label}
+          className="flex w-full items-center justify-between space-x-3 md:grid md:grid-cols-1 md:grid-rows-2 md:items-start md:space-x-0 lg:flex lg:w-auto lg:items-center lg:justify-start lg:gap-x-1"
+        >
+          <span className="font-normal text-gray-500">{item.label}</span>
+          <span className="tracking-tighter">{item.value}</span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -68,14 +77,11 @@ function Timer({ deadline }: { deadline: number | undefined }) {
   const { days, hours, minutes, seconds } = useTimer(deadline, SECOND);
 
   return (
-    <div>
-      <span className="font-normal">Next Epoch: </span>
-      <span className="tracking-tighter">
-        {days + hours + minutes + seconds <= 0
-          ? "0d_0h_0m"
-          : `${days}d_${hours}h_${minutes}m_${seconds}s`}
-      </span>
-    </div>
+    <>
+      {days + hours + minutes + seconds <= 0
+        ? "0d_0h_0m"
+        : `${days}d_${hours}h_${minutes}m_${seconds}s`}
+    </>
   );
 }
 

--- a/Frontend-v1-Original/components/header/mobileHeader.tsx
+++ b/Frontend-v1-Original/components/header/mobileHeader.tsx
@@ -19,8 +19,8 @@ function SiteLogo(props: { className?: string }) {
       className={className}
       src="/images/vcm_logo.png"
       alt="velocimeter logo"
-      height={38}
-      width={256}
+      height={682}
+      width={4643}
     />
   );
 }
@@ -44,7 +44,7 @@ function Header() {
             onClick={() => router.push("/home")}
             className="flex cursor-pointer items-center justify-center gap-2 rounded-[40px] py-5"
           >
-            <SiteLogo />
+            <SiteLogo className="h-[38px] w-auto" />
           </a>
           <button onClick={() => setOpen((prev) => !prev)}>
             {open ? <Close /> : <MenuIcon />}
@@ -56,13 +56,13 @@ function Header() {
           onClose={() => setOpen(false)}
           className="relative md:hidden"
           PaperProps={{
-            className: "flex flex-col items-start py-5 px-6 space-y-2",
+            className: "flex flex-col items-start py-5 px-6",
           }}
           data-rk
         >
           <button
             onClick={() => setOpen(false)}
-            className="absolute top-0 right-6 flex h-[78px] cursor-pointer items-center"
+            className="absolute top-5 right-5 flex h-[40px] cursor-pointer items-center"
           >
             <Close />
           </button>
@@ -90,7 +90,9 @@ function Header() {
               </IconButton>
             )}
           </div>
+          <div className="h-10"></div>
           <Navigation />
+          <div className="h-10"></div>
           <Info />
           <TransactionQueue />
         </Drawer>

--- a/Frontend-v1-Original/components/layout/layout.tsx
+++ b/Frontend-v1-Original/components/layout/layout.tsx
@@ -39,7 +39,7 @@ export default function Layout({
             <div className="block md:hidden">
               <MobileHeader />
             </div>
-            <div className="sticky top-0 z-10 hidden md:block">
+            <div className="z-10 hidden md:block">
               <Header />
             </div>
           </>

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -83,8 +83,10 @@ function Navigation() {
       <Link
         href={"/" + link}
         className={`cursor-pointer select-none appearance-none rounded-lg px-[14px] py-2 text-sm capitalize no-underline outline-0 transition-colors lg:text-base ${
-          active === link ? "bg-cyan text-black hover:text-white" : ""
-        } hover:bg-[hsla(0,0%,100%,.04)]`}
+          active === link
+            ? "bg-cyan text-black"
+            : "hover:bg-[hsla(0,0%,100%,.04)]"
+        }`}
       >
         {title}
       </Link>

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -53,7 +53,7 @@ function Navigation() {
   const renderDocsTab = () => {
     return (
       <button
-        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[14px] pt-2 pb-[10px] text-sm font-medium capitalize no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
+        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-start rounded-lg border border-transparent bg-transparent px-[14px] pt-2 pb-[10px] text-sm font-medium capitalize no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
         onClick={() => window.open("https://docs.velocimeter.xyz/", "_blank")}
       >
         <div className="m-0 pl-0 text-center text-xs xs:text-base">Docs</div>
@@ -64,7 +64,7 @@ function Navigation() {
   const renderScantoTab = () => {
     return (
       <button
-        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center gap-1 rounded-lg border border-transparent bg-transparent px-[14px] text-sm font-medium no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
+        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-start gap-1 rounded-lg border border-transparent bg-transparent px-[14px] text-sm font-medium no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
         onClick={() => window.open("https://www.scanto.io/", "_blank")}
       >
         <Image

--- a/Frontend-v1-Original/components/navigation/navigation.tsx
+++ b/Frontend-v1-Original/components/navigation/navigation.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import Image from "next/image";
 import Link from "next/link";
+import Image from "next/image";
 
 function Navigation() {
   const router = useRouter();
@@ -50,25 +50,10 @@ function Navigation() {
     );
   };
 
-  const renderSubNav = (title: string, link: string) => {
-    return (
-      <Link
-        href={"/" + link}
-        className={`relative m-0 cursor-pointer select-none appearance-none rounded-lg border bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondaryGray no-underline outline-0 ${
-          active === link
-            ? "border-cantoGreen text-white"
-            : "border-transparent"
-        } inline-flex items-center justify-center hover:bg-[hsla(0,0%,100%,.04)]`}
-      >
-        <div className="m-0 pl-0 text-center text-xs xs:text-base">{title}</div>
-      </Link>
-    );
-  };
-
   const renderDocsTab = () => {
     return (
       <button
-        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[24px] pt-2 pb-[10px] text-sm font-medium capitalize text-secondaryGray no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
+        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center rounded-lg border border-transparent bg-transparent px-[14px] pt-2 pb-[10px] text-sm font-medium capitalize no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
         onClick={() => window.open("https://docs.velocimeter.xyz/", "_blank")}
       >
         <div className="m-0 pl-0 text-center text-xs xs:text-base">Docs</div>
@@ -79,7 +64,7 @@ function Navigation() {
   const renderScantoTab = () => {
     return (
       <button
-        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center gap-1 rounded-lg border border-transparent bg-transparent p-1 text-sm font-medium text-secondaryGray no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
+        className="relative m-0 inline-flex cursor-pointer select-none appearance-none items-center justify-center gap-1 rounded-lg border border-transparent bg-transparent px-[14px] text-sm font-medium no-underline outline-0 hover:bg-[hsla(0,0%,100%,.04)]"
         onClick={() => window.open("https://www.scanto.io/", "_blank")}
       >
         <Image
@@ -93,15 +78,24 @@ function Navigation() {
     );
   };
 
+  const renderSubNav = (title: string, link: string) => {
+    return (
+      <Link
+        href={"/" + link}
+        className={`cursor-pointer select-none appearance-none rounded-lg px-[14px] py-2 text-sm capitalize no-underline outline-0 transition-colors lg:text-base ${
+          active === link ? "bg-cyan text-black hover:text-white" : ""
+        } hover:bg-[hsla(0,0%,100%,.04)]`}
+      >
+        {title}
+      </Link>
+    );
+  };
+
+
   return (
-    <>
-      <div className="flex items-center rounded-2xl border-0 bg-transparent p-2 text-center shadow-[0_0_0.2em] shadow-cantoGreen max-md:hidden">
-        {renderNavs()}
-      </div>
-      <div className="flex flex-col items-start py-2 text-center md:hidden">
-        {renderNavs()}
-      </div>
-    </>
+    <div className="grid w-full grid-cols-1 gap-y-1 md:flex md:w-auto md:items-center md:gap-x-1 md:rounded-2xl md:border-0 md:bg-transparent md:p-2 md:text-center">
+      {renderNavs()}
+    </div>
   );
 }
 

--- a/Frontend-v1-Original/e2e/navbar-clickable.test.ts
+++ b/Frontend-v1-Original/e2e/navbar-clickable.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+const swap = "http://localhost:3000/swap";
+
+// in case we have regression when refactor, like navbar gets hidden due to negative z-index
+test("Liquidity link should be clickable", async ({ page }) => {
+  await page.goto(swap);
+
+  // Click the Liquidity link.
+  await page.getByRole("link", { name: "Liquidity" }).click();
+
+  // Expects the URL to contain liquidity.
+  await expect(page).toHaveURL(/.*liquidity/);
+});

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "tsc": "tsc --noEmit",
     "prepare": "cd .. && husky install Frontend-v1-Original/.husky",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "PORT=3000 playwright test"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
@@ -36,6 +37,7 @@
     "wagmi": "^1.3.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.35.1",
     "@tanstack/eslint-plugin-query": "^4.29.4",
     "@types/cors": "^2.8.13",
     "@types/node": "^18.16.1",

--- a/Frontend-v1-Original/package.json
+++ b/Frontend-v1-Original/package.json
@@ -11,7 +11,7 @@
     "tsc": "tsc --noEmit",
     "prepare": "cd .. && husky install Frontend-v1-Original/.husky",
     "test": "vitest",
-    "test:e2e": "PORT=3000 playwright test"
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",

--- a/Frontend-v1-Original/playwright.config.ts
+++ b/Frontend-v1-Original/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run start",
+    command: "npm run dev",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
   },

--- a/Frontend-v1-Original/playwright.config.ts
+++ b/Frontend-v1-Original/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run start",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/Frontend-v1-Original/playwright.config.ts
+++ b/Frontend-v1-Original/playwright.config.ts
@@ -73,5 +73,7 @@ export default defineConfig({
     command: "PORT=3000 npm run dev",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // chances are next.js is slow to start on CI because of low resources
+    // see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
   },
 });

--- a/Frontend-v1-Original/playwright.config.ts
+++ b/Frontend-v1-Original/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
+    command: "PORT=3000 npm run dev",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
   },

--- a/Frontend-v1-Original/stores/connectors/viem.ts
+++ b/Frontend-v1-Original/stores/connectors/viem.ts
@@ -43,7 +43,7 @@ const { chains, publicClient } = configureChains(
   [
     jsonRpcProvider({
       rpc: () => ({
-        http: process.env.NEXT_PUBLIC_RPC_URL!,
+        http: process.env.NEXT_PUBLIC_RPC_URL ?? 'https://canto.gravitychain.io',
       }),
     }),
     jsonRpcProvider({

--- a/Frontend-v1-Original/stores/connectors/viem.ts
+++ b/Frontend-v1-Original/stores/connectors/viem.ts
@@ -43,7 +43,7 @@ const { chains, publicClient } = configureChains(
   [
     jsonRpcProvider({
       rpc: () => ({
-        http: process.env.NEXT_PUBLIC_RPC_URL!,
+        http: "https://canto.gravitychain.io",
       }),
     }),
     jsonRpcProvider({

--- a/Frontend-v1-Original/stores/connectors/viem.ts
+++ b/Frontend-v1-Original/stores/connectors/viem.ts
@@ -69,17 +69,22 @@ const { chains, publicClient } = configureChains(
 //   chains,
 // });
 const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID!;
+// we don't really have NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID under testing environment
+let wallets = [rabbyWallet({ chains })];
+if (projectId) {
+  wallets = [
+    ...wallets,
+    metaMaskWallet({ projectId, chains }),
+    walletConnectWallet({
+      projectId,
+      chains,
+    }),
+  ];
+}
 const connectors = connectorsForWallets([
   {
     groupName: "Recommended",
-    wallets: [
-      rabbyWallet({ chains }),
-      metaMaskWallet({ projectId, chains }),
-      walletConnectWallet({
-        projectId,
-        chains,
-      }),
-    ],
+    wallets,
   },
 ]);
 

--- a/Frontend-v1-Original/stores/connectors/viem.ts
+++ b/Frontend-v1-Original/stores/connectors/viem.ts
@@ -43,7 +43,7 @@ const { chains, publicClient } = configureChains(
   [
     jsonRpcProvider({
       rpc: () => ({
-        http: "https://canto.gravitychain.io",
+        http: process.env.NEXT_PUBLIC_RPC_URL!,
       }),
     }),
     jsonRpcProvider({

--- a/Frontend-v1-Original/tailwind.config.js
+++ b/Frontend-v1-Original/tailwind.config.js
@@ -48,6 +48,9 @@ module.exports = {
         primaryBg: "#272826",
         deepBlue: "#212b48",
         deepPurple: "#040105",
+        cyan: {
+          DEFAULT: '#00E8CA',
+        }
       },
       boxShadow: {
         glow: "0 0 10px 0 #06fc99",

--- a/Frontend-v1-Original/vitest.config.ts
+++ b/Frontend-v1-Original/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./scripts/env-setup.ts"],
+    exclude: [...configDefaults.exclude, "**/e2e/**"],
   },
 });

--- a/Frontend-v1-Original/yarn.lock
+++ b/Frontend-v1-Original/yarn.lock
@@ -1199,6 +1199,16 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@playwright/test@^1.35.1":
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.1.tgz#a596b61e15b980716696f149cc7a2002f003580c"
+  integrity sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.35.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 "@popperjs/core@^2.11.6":
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
@@ -4080,7 +4090,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -5687,6 +5697,11 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.35.1:
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.1.tgz#52c1e6ffaa6a8c29de1a5bdf8cce0ce290ffb81d"
+  integrity sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==
 
 pngjs@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `.test-results/`, `.playwright-report/`, and `.playwright/.cache/` to `.gitignore` file.
- Added `cyan` color to `tailwind.config.js`.
- Updated `layout.tsx` to remove `sticky` class from `div` element.
- Updated `vitest.config.ts` to exclude `**/e2e/**` from test coverage.
- Added `test:e2e` script to `package.json` to run Playwright tests.
- Added `e2e/navbar-clickable.test.ts` for testing navbar clickability.
- Updated `PageWrapper.tsx` to change `h-[calc(100%-150px)]` to `h-full` in `Paper` component.
- Added `playwright.yml` workflow file for running Playwright tests.
- Updated `viem.ts` to use default RPC URL if `NEXT_PUBLIC_RPC_URL` is not defined.
- Updated `header.tsx` to change `SiteLogo` dimensions.
- Updated `mobileHeader.tsx` to change `SiteLogo` dimensions.
- Updated `header.tsx` to change `Close` button dimensions.
- Updated `header.tsx` to add empty `div` elements for spacing.
- Updated `header.tsx` to add `span` element for `ConnectButton` positioning.
- Updated `playwright.config.ts` to configure Playwright tests

> The following files were skipped due to too many changes: `Frontend-v1-Original/components/header/info.tsx`, `Frontend-v1-Original/components/navigation/navigation.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->