### PR TITLE
Move APR and TVL next to pair name

### DIFF
--- a/Frontend-v1-Original/components/liquidityPairs/LiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/liquidityPairs/LiquidityPairsTable.tsx
@@ -45,6 +45,18 @@ const headCells = [
   { id: "expand", numeric: false, disablePadding: true, label: "" },
   { id: "pair", numeric: false, disablePadding: false, label: "Pair" },
   {
+    id: "apr",
+    numeric: true,
+    disablePadding: false,
+    label: "APR",
+  },
+  {
+    id: "tvl",
+    numeric: true,
+    disablePadding: false,
+    label: "TVL",
+  },
+  {
     id: "balance",
     numeric: true,
     disablePadding: false,
@@ -73,18 +85,6 @@ const headCells = [
     numeric: true,
     disablePadding: false,
     label: "Total Pool Staked",
-  },
-  {
-    id: "tvl",
-    numeric: true,
-    disablePadding: false,
-    label: "TVL",
-  },
-  {
-    id: "apr",
-    numeric: true,
-    disablePadding: false,
-    label: "APR",
   },
   {
     id: "",
@@ -583,6 +583,34 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
             </div>
           </div>
         </TableCell>
+        <TableCell align="right">
+          <div className="flex items-center justify-end gap-1">
+            {row.isAliveGauge === false && (
+              <Tooltip title="Gauge has been killed">
+                <WarningOutlined className="ml-2 text-base text-yellow-300" />
+              </Tooltip>
+            )}
+            {row.oblotr_apr > 0 && (
+              <Tooltip
+                title={`oFVM APR BOOST ${row.oblotr_apr.toFixed(
+                  2
+                )}%. Use at Options page`}
+              >
+                <Link href={`/options`}>
+                  <LocalFireDepartmentOutlined className="ml-2 text-base text-orange-600" />
+                </Link>
+              </Tooltip>
+            )}
+            <Typography variant="h2" className="text-xs font-extralight">
+              {(row.apr + row.oblotr_apr).toFixed(2)}%
+            </Typography>
+          </div>
+        </TableCell>
+        <TableCell className="max-2xl:hidden" align="right">
+          <Typography variant="h2" className="text-xs font-extralight">
+            {formatTVL(row.tvl)}
+          </Typography>
+        </TableCell>
         <TableCell className="max-md:hidden" align="right">
           {row &&
             row.token0 &&
@@ -872,34 +900,6 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
             </Typography>
           </TableCell>
         )}
-        <TableCell className="max-2xl:hidden" align="right">
-          <Typography variant="h2" className="text-xs font-extralight">
-            {formatTVL(row.tvl)}
-          </Typography>
-        </TableCell>
-        <TableCell align="right">
-          <div className="flex items-center justify-end gap-1">
-            {row.isAliveGauge === false && (
-              <Tooltip title="Gauge has been killed">
-                <WarningOutlined className="ml-2 text-base text-yellow-300" />
-              </Tooltip>
-            )}
-            {row.oblotr_apr > 0 && (
-              <Tooltip
-                title={`oFVM APR BOOST ${row.oblotr_apr.toFixed(
-                  2
-                )}%. Use at Options page`}
-              >
-                <Link href={`/options`}>
-                  <LocalFireDepartmentOutlined className="ml-2 text-base text-orange-600" />
-                </Link>
-              </Tooltip>
-            )}
-            <Typography variant="h2" className="text-xs font-extralight">
-              {(row.apr + row.oblotr_apr).toFixed(2)}%
-            </Typography>
-          </div>
-        </TableCell>
         <TableCell align="right">
           <Button
             variant="outlined"

--- a/Frontend-v1-Original/components/liquidityPairs/LiquidityPairsTable.tsx
+++ b/Frontend-v1-Original/components/liquidityPairs/LiquidityPairsTable.tsx
@@ -121,9 +121,9 @@ function EnhancedTableHead(props: {
         {headCells.map((headCell) => (
           <TableCell
             className={`border-b border-b-[rgba(104,108,122,0.2)] ${
-              headCell.id === "tvl"
+              headCell.id === "poolAmount"
                 ? "max-2xl:hidden"
-                : headCell.id === "poolAmount" ||
+                : headCell.id === "tvl" ||
                   headCell.id === "stakedAmount" ||
                   headCell.id === "balance" ||
                   headCell.id === "poolBalance"
@@ -606,7 +606,7 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
             </Typography>
           </div>
         </TableCell>
-        <TableCell className="max-2xl:hidden" align="right">
+        <TableCell className="max-md:hidden" align="right">
           <Typography variant="h2" className="text-xs font-extralight">
             {formatTVL(row.tvl)}
           </Typography>
@@ -785,7 +785,7 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
             </Typography>
           </TableCell>
         )}
-        <TableCell className="max-md:hidden" align="right">
+        <TableCell className="max-2xl:hidden" align="right">
           {row && row.token0 && (
             <div className="flex items-center justify-end max-md:block">
               <Typography variant="h2" className="text-xs font-extralight">


### PR DESCRIPTION
And also show TVL instead of Total Pool Balance between `md` and `2xl`

**Before**
<img width="1322" alt="Screenshot 2023-07-09 at 6 12 39 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/30633293-f2ac-489a-b86b-ffeaaa24b319">
<img width="1496" alt="Screenshot 2023-07-09 at 6 12 48 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/d3d100ec-9b16-41a1-9bad-5978afafcce3">

**After**
<img width="1323" alt="Screenshot 2023-07-09 at 6 13 32 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/3e7f7993-696c-4ae8-b0c7-6e12d828fb78">
<img width="1450" alt="Screenshot 2023-07-09 at 6 13 41 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/85a6127f-7ee2-4072-b7fb-3334ac974d46">


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added "APR" and "TVL" columns to the LiquidityPairsTable component
- Reordered the columns to display "APR" and "TVL" columns after the "Total Pool Staked" column
- Updated the rendering logic in the EnhancedTableHead component to handle the new columns
- Updated the rendering logic in the Row component to display the new "APR" and "TVL" values
- Added tooltips and icons for additional information in the "APR" column

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->