### PR TITLE
update codebase for aprs range

### DIFF
--- a/components/liquidityManage/lib/queries.ts
+++ b/components/liquidityManage/lib/queries.ts
@@ -375,7 +375,7 @@ export const getPairByAddress = async (
       logoURI: "",
       local: false,
     },
-    apr: 0,
+    aprs: null, // we don't need to know aprs here
     oblotr_apr: 0,
     total_supply: 0,
     token0_address: token0,

--- a/components/liquidityPairs/LiquidityPairsTable.tsx
+++ b/components/liquidityPairs/LiquidityPairsTable.tsx
@@ -498,7 +498,7 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
     tokens[row.token1.address.toLowerCase() as keyof typeof tokens];
   return (
     <>
-      <TableRow>
+      <TableRow className="hover:bg-background/50">
         <TableCell align="right" size="small">
           <IconButton
             aria-label="expand row"
@@ -582,19 +582,8 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
                 "apr" in apr ? (
                   <div
                     key={apr.apr + apr.symbol + apr.logo}
-                    className="flex justify-between items-center w-full"
+                    className="flex justify-end items-center w-full"
                   >
-                    <img
-                      src={apr.logo}
-                      title={apr.symbol}
-                      alt={`${apr.symbol} apr`}
-                      className="block h-5 w-5 rounded-full"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).onerror = null;
-                        (e.target as HTMLImageElement).src =
-                          "/tokens/unknown-logo.png";
-                      }}
-                    />
                     <h2 className="text-xs font-extralight">
                       {apr.apr.toFixed()}% {apr.symbol}
                     </h2>
@@ -602,19 +591,8 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
                 ) : (
                   <div
                     key={apr.min_apr + apr.max_apr + apr.symbol + apr.logo}
-                    className="flex justify-between items-center w-full"
+                    className="flex justify-end items-center w-full"
                   >
-                    <img
-                      src={apr.logo}
-                      title={apr.symbol}
-                      alt={`${apr.symbol} apr`}
-                      className="block h-5 w-5 rounded-full"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).onerror = null;
-                        (e.target as HTMLImageElement).src =
-                          "/tokens/unknown-logo.png";
-                      }}
-                    />
                     <h2 className="text-xs font-extralight">
                       {apr.min_apr.toFixed()}-{apr.max_apr.toFixed()}%{" "}
                       {apr.symbol}

--- a/components/liquidityPairs/LiquidityPairsTable.tsx
+++ b/components/liquidityPairs/LiquidityPairsTable.tsx
@@ -575,9 +575,7 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
           <div className="flex flex-col items-center justify-end gap-1">
             {row.aprs === null ? (
               <div className="flex justify-end w-full">
-                <Typography variant="h2" className="text-xs font-extralight">
-                  {0}%
-                </Typography>
+                <h2 className="text-xs font-extralight">{0}%</h2>
               </div>
             ) : (
               row.aprs.map((apr) =>
@@ -597,12 +595,9 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
                           "/tokens/unknown-logo.png";
                       }}
                     />
-                    <Typography
-                      variant="h2"
-                      className="text-xs font-extralight"
-                    >
+                    <h2 className="text-xs font-extralight">
                       {apr.apr.toFixed()}% {apr.symbol}
-                    </Typography>
+                    </h2>
                   </div>
                 ) : (
                   <div
@@ -620,13 +615,10 @@ function Row(props: { row: Pair; onView: (_row: Pair) => void }) {
                           "/tokens/unknown-logo.png";
                       }}
                     />
-                    <Typography
-                      variant="h2"
-                      className="text-xs font-extralight"
-                    >
+                    <h2 className="text-xs font-extralight">
                       {apr.min_apr.toFixed()}-{apr.max_apr.toFixed()}%{" "}
                       {apr.symbol}
-                    </Typography>
+                    </h2>
                   </div>
                 )
               )

--- a/components/options/lib/useGaugeApr.ts
+++ b/components/options/lib/useGaugeApr.ts
@@ -109,8 +109,8 @@ function getGaugeApr(
     +veDiscount
   );
 
-  const minDiscountFactor = (100 - minDiscount) / 100;
-  const maxDiscountFactor = (100 - maxDiscount) / 100;
+  const minDiscountFactor = minDiscount / 100;
+  const maxDiscountFactor = maxDiscount / 100;
 
   const map = new Map<Token, readonly [number, number]>(); // [minApr, maxApr]
 
@@ -124,8 +124,8 @@ function getGaugeApr(
       const fullUnderlyingTokenPrice =
         tokenPrices.get(underlyingTokenAddress.toLowerCase()) ?? 0;
 
-      const maxPrice = fullUnderlyingTokenPrice * minDiscountFactor;
-      const minPrice = fullUnderlyingTokenPrice * maxDiscountFactor;
+      const maxPrice = fullUnderlyingTokenPrice * maxDiscountFactor;
+      const minPrice = fullUnderlyingTokenPrice * minDiscountFactor;
 
       const maxApr =
         ((rewardToken.reward * maxPrice) / totalStakedValue) * 100 * 365;

--- a/lib/global/queries.ts
+++ b/lib/global/queries.ts
@@ -476,18 +476,6 @@ export const getPairsWithGauges = async (
         functionName: "weights",
         args: [pair.address],
       },
-      {
-        address: pair.gauge.address,
-        abi: CONTRACTS.GAUGE_ABI,
-        functionName: "left",
-        args: [CONTRACTS.GOV_TOKEN_ADDRESS],
-      },
-      {
-        address: pair.gauge.address,
-        abi: CONTRACTS.GAUGE_ABI,
-        functionName: "left",
-        args: [CONTRACTS.OPTION_TOKEN_ADDRESS],
-      },
     ] as const;
   });
   const gaugesCallsChunks = chunkArray(gaugesCalls);
@@ -499,8 +487,10 @@ export const getPairsWithGauges = async (
     if (hasGauge(pair)) {
       const isAliveGauge = gaugesAliveData[outerIndex];
 
-      const [totalSupply, gaugeBalance, gaugeWeight, flowLeft, optionLeft] =
-        gaugesData.slice(outerIndex * 5, outerIndex * 5 + 5);
+      const [totalSupply, gaugeBalance, gaugeWeight] = gaugesData.slice(
+        outerIndex * 3,
+        outerIndex * 3 + 3
+      );
 
       pair.gauge.balance = formatEther(gaugeBalance);
       pair.gauge.totalSupply = +formatEther(totalSupply);
@@ -528,9 +518,6 @@ export const getPairsWithGauges = async (
       ).toFixed(2);
       pair.gaugebribes = pair.gauge.bribes;
       pair.isAliveGauge = isAliveGauge;
-      if (isAliveGauge === false) pair.apr = 0;
-      if (flowLeft === 0n) pair.apr = 0;
-      if (optionLeft === 0n) pair.oblotr_apr = 0;
 
       outerIndex++;
     }

--- a/stores/types/types.ts
+++ b/stores/types/types.ts
@@ -55,9 +55,24 @@ interface Bribe {
 
 type BribeEarned = { earned: string };
 
+interface GeneralApr {
+  symbol: string;
+  logo: string;
+  apr: number;
+}
+
+interface OptionApr {
+  symbol: string;
+  logo: string;
+  min_apr: number;
+  max_apr: number;
+}
+
+type Aprs = (GeneralApr | OptionApr)[] | null;
+
 interface Pair {
   tvl: number;
-  apr: number;
+  aprs: Aprs;
   oblotr_apr: number;
   address: `0x${string}`;
   symbol: string;
@@ -335,6 +350,7 @@ export type {
   FireBirdTokens,
   PairsCallResponse,
   Rewards,
+  Aprs,
 };
 
 export { hasGauge, isGaugeReward, isBaseAsset, TransactionStatus };


### PR DESCRIPTION
use this `https://p01--test-aprs--wlcfywkylwkq.code.run` to test.

This PR updates current displayed APR to show APR range coming from backend or apr if it's not option reward.

**Before:**
<img width="1343" alt="Screenshot 2023-07-10 at 8 39 01 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/58e36ee2-183a-4f99-825f-8de46221bb79">

**After:**
![image](https://github.com/Velocimeter/frontend/assets/90512605/d4723ecc-5b11-4b17-bd9d-629e37567f65)

This PR has to be considered and merged simultaneously with [PR 7 in API repo](https://github.com/Velocimeter/api/pull/7).

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the LiquidityPairsTable component to display APR values for each pair, including both general APR and option APR.

### Detailed summary:
- Added `aprs` property to the `Pair` interface in `types.ts`.
- Modified the `LiquidityPairsTable` component to display the APR values for each pair.
- Updated the `useGaugeApr` function to calculate the minimum and maximum discount factors correctly.
- Updated the `getGaugeApr` function to calculate the maximum and minimum prices correctly.
- Updated the `pairs.ts` API handler to parse and filter the `aprs` data for each pair.
- Updated the `getPairsWithGauges` function to handle the changes in the `gaugesData` array.
- Updated the `EnhancedTableToolbar` component to display the filter options correctly.
- Updated the `Row` component in the `LiquidityPairsTable` to display the APR values for each pair.
- Added tooltips and icons to indicate the status of the gauge and oFVM APR boost.
- Updated the sorting logic in the `descendingComparator` function to consider the new APR values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->