### PR TITLE
remove $ from apr

### DIFF
--- a/components/stake/StakeFVM.tsx
+++ b/components/stake/StakeFVM.tsx
@@ -226,7 +226,7 @@ export function StakeFVM() {
                     className="flex items-center justify-end gap-2"
                   >
                     <div>
-                      {apr.minApr} - ${apr.maxApr}%
+                      {apr.minApr} - {apr.maxApr}%
                     </div>
                     <div>{apr.symbol}</div>
                   </div>


### PR DESCRIPTION
A community member reported it in our discord:

![image](https://github.com/Velocimeter/frontend/assets/126733611/544b401e-f07e-46a0-98b1-c7635ece907a)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed the formatting of the APR display in `StakeFVM.tsx` to remove the dollar sign and add a symbol after the range.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->