### PR TITLE
aggregate aprs

### DIFF
--- a/components/options/lib/aggregateApr.test.ts
+++ b/components/options/lib/aggregateApr.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { aggregateApr } from "./aggregateApr";
+
+type ADDRESS = `0x${string}`;
+
+const tokenA = {
+  symbol: "a",
+  address: "0x1" as ADDRESS,
+  decimals: 18,
+  reward: 1,
+  logoUrl: "",
+};
+
+const tokenB = {
+  symbol: "b",
+  address: "0x2" as ADDRESS,
+  decimals: 18,
+  reward: 1,
+  logoUrl: "",
+};
+describe("aggregateApr", () => {
+  it("should aggregate aprRange for the same token symbol", () => {
+    const aprs = [
+      {
+        aprRange: [1, 2] as const,
+        ...tokenA,
+      },
+      {
+        aprRange: [3, 4] as const,
+        ...tokenA,
+      },
+      {
+        aprRange: [5, 6] as const,
+        ...tokenB,
+      },
+    ];
+    const result = aggregateApr(aprs);
+    expect(result).toEqual([
+      {
+        aprRange: [4, 6],
+        ...tokenA,
+      },
+      {
+        aprRange: [5, 6],
+        ...tokenB,
+      },
+    ]);
+  });
+});

--- a/components/options/lib/aggregateApr.ts
+++ b/components/options/lib/aggregateApr.ts
@@ -1,0 +1,26 @@
+type MIN_APR = number;
+type MAX_APR = number;
+interface APR {
+  apr?: number;
+  aprRange?: readonly [MIN_APR, MAX_APR];
+  address: `0x${string}`;
+  symbol: string;
+  decimals: number;
+  reward: number;
+  logoUrl: string | undefined;
+}
+export function aggregateApr(arr: APR[]) {
+  // aggreate aprRange for the same token symbol
+  const map = new Map<string, APR>();
+  for (const apr of arr) {
+    const existingApr = map.get(apr.symbol);
+    if (existingApr) {
+      const [min, max] = apr.aprRange ?? [0, 0];
+      const [existingMin, existingMax] = existingApr.aprRange ?? [0, 0];
+      existingApr.aprRange = [min + existingMin, max + existingMax] as const;
+    } else {
+      map.set(apr.symbol, apr);
+    }
+  }
+  return [...map.values()];
+}

--- a/components/options/lib/useGaugeApr.ts
+++ b/components/options/lib/useGaugeApr.ts
@@ -8,6 +8,7 @@ import { type Token, useGaugeRewardTokens } from "./useGaugeRewards";
 import { useStakeData } from "./useStakeData";
 import { useDiscountsData } from "./useDiscountsData";
 import { useIsEmittingOptions } from "./useIsEmittingOptions";
+import { aggregateApr } from "./aggregateApr";
 
 export function useGaugeApr() {
   const { data: rewardTokens } = useGaugeRewardTokens();
@@ -150,5 +151,7 @@ function getGaugeApr(
     }
   }
 
-  return arr;
+  const aggreatedApr = aggregateApr(arr);
+
+  return aggreatedApr;
 }

--- a/components/options/stake.tsx
+++ b/components/options/stake.tsx
@@ -225,14 +225,15 @@ export function Stake() {
                   className="flex items-center justify-end gap-2"
                 >
                   <div>
-                    {"aprRange" in token
+                    {typeof token.aprRange !== "undefined"
                       ? `${formatCurrency(
                           token.aprRange[0]
-                        )} % - ${formatCurrency(token.aprRange[1])} %`
+                        )} - ${formatCurrency(token.aprRange[1])}%`
                       : `
-                  ${formatCurrency(token.apr)} %
+                  ${formatCurrency(token.apr)}%
                   `}
                   </div>
+                  {token.symbol}
                   <img
                     src={token.logoUrl ?? "/tokens/unknown-logo.png"}
                     title={token.symbol}


### PR DESCRIPTION
Similar to https://github.com/Velocimeter/frontend/pull/258, unit test included.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on aggregating `aprRange` for the same token symbol in the `useGaugeApr` hook.

### Detailed summary:
- Added `aggregateApr` function to aggregate `aprRange` for the same token symbol.
- Modified `useGaugeApr` hook to use `aggregateApr` function.
- Added tests for `aggregateApr` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->