### PR TITLE
disable refetchOnWindowFocus

### DIFF
--- a/components/ssVotes/lib/queries.ts
+++ b/components/ssVotes/lib/queries.ts
@@ -28,6 +28,7 @@ export const useVestVotes = (tokenID: string | undefined) => {
     queryFn: () => getVestVotes(address, tokenID, pairs),
     enabled: !!address && !!tokenID && !!pairs,
     refetchOnMount: false,
+    refetchOnWindowFocus: false,
     select: (votes) => {
       const votesValues: Votes | undefined = votes?.map((vote) => {
         return {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding the `refetchOnWindowFocus` property to the `queries.ts` file in the `ssVotes` component.

### Detailed summary:
- Added `refetchOnWindowFocus: false` property to the `queries.ts` file in the `ssVotes` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->