### PR TITLE
clean up vitest configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,6 @@
 import { configDefaults, defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
   test: {
     environment: "jsdom",
     setupFiles: ["./scripts/env-setup.ts"],


### PR DESCRIPTION
Believe I've made a mistake here. Those should belong to `vite`, not `vitest`. And it's causing issue here https://github.com/Velocimeter/frontend/pull/274

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `vitest.config.ts` file. 

### Detailed summary:
- Removed the import statement for the `@vitejs/plugin-react` package.
- Added the `test` configuration object with the following properties:
  - `environment` set to "jsdom".
  - `setupFiles` array containing "./scripts/env-setup.ts".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->