### PR TITLE
fix the apr data when total staked is zero

### DIFF
--- a/components/options/lib/useGaugeApr.ts
+++ b/components/options/lib/useGaugeApr.ts
@@ -161,7 +161,9 @@ function getGaugeApr(
     const isGovTokenEmittedAsOption =
       rewardToken.address.toLowerCase() ===
         CONTRACTS.GOV_TOKEN_ADDRESS.toLowerCase() && isEmittingOptions;
-    if (isUnderlyingTokenEmittedAsOption || isOptionToken) {
+    if (totalStakedValue === 0) {
+      map.set(rewardToken, [0, 0] as const);
+    } else if (isUnderlyingTokenEmittedAsOption || isOptionToken) {
       const fullUnderlyingTokenPrice =
         tokenPrices.get(underlyingTokenAddress.toLowerCase()) ?? 0;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on updating the `useGaugeApr` function in the `components/options/lib` directory. The notable changes include:

- Adding a condition to set a reward token with a stake value of 0.
- Updating the calculation of `fullUnderlyingTokenPrice` based on the `tokenPrices` map.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->