### PR TITLE
DO NOT USE EXTERNAL BRIBE FROM GAUGE CONTRACT

### DIFF
--- a/components/liquidityManage/lib/mutations.ts
+++ b/components/liquidityManage/lib/mutations.ts
@@ -813,7 +813,7 @@ const writeCreateGauge = async (
       address: CONTRACTS.VOTER_ADDRESS,
       abi: CONTRACTS.VOTER_ABI,
       functionName: "createGauge",
-      args: [pairAddress, 0n],
+      args: [pairAddress, 1n],
     });
     const txHash = await walletClient.writeContract(request);
     return txHash;

--- a/components/ssVotes/ssVotesTable.tsx
+++ b/components/ssVotes/ssVotesTable.tsx
@@ -286,7 +286,7 @@ export default function EnhancedTable({
                 token={token}
                 defaultVotes={defaultVotes}
                 onSliderChange={onSliderChange}
-                key={row.address}
+                key={row.address + row.gauge.address}
               />
             ))}
             {emptyRows > 0 && (
@@ -331,9 +331,8 @@ const VotesRow = memo(function VotesRow({
   const token1Info =
     tokens[row.token1.address.toLowerCase() as keyof typeof tokens];
 
-  let sliderValue = defaultVotes?.find(
-    (el) => el.address === row?.address
-  )?.value;
+  let sliderValue = defaultVotes?.find((el) => el.address === row?.address)
+    ?.value;
   if (!sliderValue) {
     sliderValue = 0;
   }
@@ -712,12 +711,10 @@ function descendingComparator(
       return 0;
 
     case "rewardEstimate":
-      const sliderValueA = defaultVotes?.find(
-        (el) => el.address === a?.address
-      )?.value;
-      const sliderValueB = defaultVotes?.find(
-        (el) => el.address === b?.address
-      )?.value;
+      const sliderValueA = defaultVotes?.find((el) => el.address === a?.address)
+        ?.value;
+      const sliderValueB = defaultVotes?.find((el) => el.address === b?.address)
+        ?.value;
       let rewardEstimateA: number | undefined;
       let rewardEstimateB: number | undefined;
 
@@ -802,12 +799,10 @@ function descendingComparator(
 
     case "myVotes":
     case "mvp":
-      const sliderValue1 = defaultVotes?.find(
-        (el) => el.address === a?.address
-      )?.value;
-      const sliderValue2 = defaultVotes?.find(
-        (el) => el.address === b?.address
-      )?.value;
+      const sliderValue1 = defaultVotes?.find((el) => el.address === a?.address)
+        ?.value;
+      const sliderValue2 = defaultVotes?.find((el) => el.address === b?.address)
+        ?.value;
       if (
         sliderValue1 !== undefined &&
         sliderValue2 !== undefined &&

--- a/stores/abis/gaugeABI.ts
+++ b/stores/abis/gaugeABI.ts
@@ -363,19 +363,6 @@ export const gaugeABI = [
   },
   {
     inputs: [],
-    name: "external_bribe",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
     name: "fees0",
     outputs: [
       {

--- a/stores/abis/maxxingGaugeABI.ts
+++ b/stores/abis/maxxingGaugeABI.ts
@@ -423,19 +423,6 @@ export const maxxingGaugeABI = [
   },
   {
     inputs: [],
-    name: "external_bribe",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
     name: "fees0",
     outputs: [
       {

--- a/stores/types/types.ts
+++ b/stores/types/types.ts
@@ -179,10 +179,11 @@ interface Rewards {
 
 type Vote = {
   address: `0x${string}`;
+  gaugeAddress: `0x${string}`;
   votePercent: string;
 };
 
-type Votes = Array<Pick<Vote, "address"> & { value: number }>;
+type Votes = Array<Pick<Vote, "address" | "gaugeAddress"> & { value: number }>;
 
 interface DexScrennerPair {
   chainId: string;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Updated the `createGauge` mutation to pass `1n` instead of `0n` as the second argument.
- Removed the `external_bribe` function from `gaugeABI.ts` and `maxxingGaugeABI.ts`.
- Added `gaugeAddress` property to the `Vote` type in `types.ts`.
- Updated the `getVestVotes` function in `queries.ts` to include the `gaugeAddress` property in the returned object.
- Updated the `getPairsWithGaugesAndVotes` function in `queries.ts` to filter based on both `address` and `gaugeAddress`.
- Removed the `bribeContractInstance` and related code from `queries.ts`.
- Updated the `getPairByAddress` function in `queries.ts` to use `viemClient` for reading contract data.
- Updated the `ssVotesTable.tsx` component to include `row.gauge.address` in the `key` prop.
- Updated the `VotesRow` component in `ssVotesTable.tsx` to retrieve the `sliderValue` based on `row.address`.
- Updated the `descendingComparator` function in `ssVotesTable.tsx` to retrieve the `sliderValue` based on `a.address` and `b.address`.
- Updated the `descendingComparator` function in `ssVotesTable.tsx` to retrieve the `sliderValue` based on `a.address` and `b.address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->