### PR TITLE
do not auto select next votable nft

### DIFF
--- a/components/ssVotes/ssVotes.tsx
+++ b/components/ssVotes/ssVotes.tsx
@@ -63,6 +63,14 @@ export default function Votes() {
   const { mutate: vote, isLoading: voteLoading } = useVote();
 
   useEffect(() => {
+    if (token.id !== initialEmptyToken.id) {
+      // if user has selected a token, we don't want to change it
+      // just re set the same token to update token data
+      setToken(
+        vestNFTs?.find((nft) => nft.id === token.id) || initialEmptyToken
+      );
+      return;
+    }
     if (vestNFTs && vestNFTs.length > 0) {
       const votableNFTs = vestNFTs.filter(
         (nft) => nft.actionedInCurrentEpoch === false
@@ -73,7 +81,7 @@ export default function Votes() {
         setToken(vestNFTs[0]);
       }
     }
-  }, [vestNFTs]);
+  }, [vestNFTs, token]);
 
   useEffect(() => {
     const localStorageWarningAccepted =


### PR DESCRIPTION
Related issue https://github.com/Velocimeter/frontend/issues/193#issuecomment-1637365612

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a condition to prevent changing the selected token if it has already been selected by the user.
- Set the same token to update its data if it has been selected.
- Updated the dependency array of the second useEffect hook to include the `token` variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->