### PR TITLE
add oBAY to selector and enable selector velocimeter pro

### DIFF
--- a/components/options/redeem.tsx
+++ b/components/options/redeem.tsx
@@ -47,7 +47,7 @@ import {
   useStakeData,
 } from "./lib";
 
-const TOKENS = ["oFVM", "oBLOTR"];
+const TOKENS = ["oFVM", "oBLOTR", "oBAY"];
 
 interface RedeemTabs {
   LP: string;
@@ -110,20 +110,18 @@ export function Redeem() {
       value={tab}
       onValueChange={handleTabChange}
     >
-      {process.env.NEXT_PUBLIC_VERCEL_ENV !== "production" && (
-        <div className="flex justify-between items-center">
-          <h3 className="text-lg">Select option token</h3>
-          <Select value={optionToken} onValueChange={setOptionToken}>
-            {TOKENS.map((token) => {
-              return (
-                <SelectItem value={token} key={token}>
-                  {token}
-                </SelectItem>
-              );
-            })}
-          </Select>
-        </div>
-      )}
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg">Select option token</h3>
+        <Select value={optionToken} onValueChange={setOptionToken}>
+          {TOKENS.map((token) => {
+            return (
+              <SelectItem value={token} key={token}>
+                {token}
+              </SelectItem>
+            );
+          })}
+        </Select>
+      </div>
       <h2 className="mb-5 text-xl">Redeem {optionTokenSymbol} Into</h2>
       <Tabs.List className="flex shrink-0" aria-label="Redeem options">
         {Object.values(tabs).map((tab) => (

--- a/stores/constants/constants.ts
+++ b/stores/constants/constants.ts
@@ -38,6 +38,9 @@ export const PRO_OPTIONS = {
   oBLOTR: {
     tokenAddress: "0xC5d4E462b96cC73283EB452B15147c17Af413313",
   },
+  oBAY: {
+    tokenAddress: "0x269557D887EaA9C1a756B2129740B3FC2821fD91",
+  },
 } as const;
 
 export const MAX_UINT256 = new BigNumber(2).pow(256).minus(1).toFixed(0);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Add a new token `oBAY` to the list of available tokens for redemption.

### Detailed summary:
- Added `oBAY` token to the `TOKENS` array in `redeem.tsx`.
- Updated the UI to display the new token in the select dropdown for option tokens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->