### PR TITLE
do not auto select next votable nft

### DIFF
--- a/components/ssVotes/ssVotes.tsx
+++ b/components/ssVotes/ssVotes.tsx
@@ -63,6 +63,14 @@ export default function Votes() {
   const { mutate: vote, isLoading: voteLoading } = useVote();
 
   useEffect(() => {
+    if (token.id !== initialEmptyToken.id) {
+      // if user has selected a token, we don't want to change it
+      // just re set the same token to update token data
+      setToken(
+        vestNFTs?.find((nft) => nft.id === token.id) || initialEmptyToken
+      );
+      return;
+    }
     if (vestNFTs && vestNFTs.length > 0) {
       const votableNFTs = vestNFTs.filter(
         (nft) => nft.votedInCurrentEpoch === false
@@ -73,7 +81,7 @@ export default function Votes() {
         setToken(vestNFTs[0]);
       }
     }
-  }, [vestNFTs]);
+  }, [vestNFTs, token]);
 
   useEffect(() => {
     const localStorageWarningAccepted =


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added a condition to prevent changing the selected token if it is already set
- Updated the token state to the same token if it exists in the vestNFTs array
- Added the token dependency to the second useEffect hook

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->