### PR TITLE
fix big amounts mess and move formatFinancialData to utils

### DIFF
--- a/components/header/info.tsx
+++ b/components/header/info.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type ReactNode } from "react";
 
 import { CONTRACTS } from "../../stores/constants/constants";
+import { formatFinancialData } from "../../utils/utils";
 
 import {
   useActivePeriod,
@@ -105,17 +106,4 @@ function useTimer(deadline = 0, interval = SECOND) {
     minutes: Math.floor((timeLeft / MINUTE) % 60),
     seconds: Math.floor((timeLeft / SECOND) % 60),
   };
-}
-
-function formatFinancialData(dataNumber: number) {
-  if (dataNumber < 10_000_000) {
-    return dataNumber.toLocaleString("en-US", {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    });
-  } else if (dataNumber < 1_000_000_000) {
-    return (dataNumber / 1_000_000).toFixed(2) + "m";
-  } else {
-    return (dataNumber / 1_000_000_000).toFixed(2) + "b";
-  }
 }

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -13,9 +13,26 @@ export function formatCurrency(amount: any, decimals = 2) {
       maximumFractionDigits: decimals,
     });
 
+    if (amount > 1_000_000_000) {
+      return formatter.format(amount / 1_000_000_000) + "b";
+    }
+
     return formatter.format(amount);
   } else {
     return "0.00";
+  }
+}
+
+export function formatFinancialData(dataNumber: number) {
+  if (dataNumber < 10_000_000) {
+    return dataNumber.toLocaleString("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+  } else if (dataNumber < 1_000_000_000) {
+    return (dataNumber / 1_000_000).toFixed(2) + "m";
+  } else {
+    return (dataNumber / 1_000_000_000).toFixed(2) + "b";
   }
 }
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -13,7 +13,7 @@ export function formatCurrency(amount: any, decimals = 2) {
       maximumFractionDigits: decimals,
     });
 
-    if (amount > 1_000_000_000) {
+    if (amount >= 1_000_000_000) {
       return formatter.format(amount / 1_000_000_000) + "b";
     }
 


### PR DESCRIPTION
**Before**
<img width="389" alt="Screenshot 2023-07-19 at 2 05 49 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/5edae77c-9503-4b2c-a46a-7420b2efb4df">
**After**
<img width="216" alt="Screenshot 2023-07-19 at 2 05 29 pm" src="https://github.com/Velocimeter/frontend/assets/90512605/041e6354-548e-47a8-83e4-176ee6c139bd">

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added import statement for `formatFinancialData` function in `info.tsx`
- Moved `formatFinancialData` function from `utils.ts` to `info.tsx` and exported it
- Updated `formatFinancialData` function in `utils.ts` to handle larger numbers with suffixes (e.g., "m" for million, "b" for billion)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->